### PR TITLE
errors: top-level error type

### DIFF
--- a/samples/server/go-server/api/server/errors/errors.go
+++ b/samples/server/go-server/api/server/errors/errors.go
@@ -1,6 +1,0 @@
-package errors
-
-type AppError struct {
-	Err        string
-	StatusCode int
-}

--- a/samples/server/go-server/api/server/handler.go
+++ b/samples/server/go-server/api/server/handler.go
@@ -18,15 +18,16 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/grafeas/grafeas/samples/server/go-server/api"
-	"github.com/grafeas/grafeas/samples/server/go-server/api/server/errors"
-	"github.com/grafeas/grafeas/samples/server/go-server/api/server/name"
-	"github.com/grafeas/grafeas/samples/server/go-server/api/server/v1alpha1"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/google/uuid"
+	"github.com/grafeas/grafeas/samples/server/go-server/api"
+	"github.com/grafeas/grafeas/samples/server/go-server/api/server/name"
+	"github.com/grafeas/grafeas/samples/server/go-server/api/server/v1alpha1"
+	"github.com/grafeas/grafeas/server-go/errors"
 )
 
 // Handler accepts httpRequests, converts them to Grafeas objects - calls into Grafeas to operation on them
@@ -81,6 +82,7 @@ func (h *Handler) CreateNote(w http.ResponseWriter, r *http.Request) {
 	if err := h.g.CreateNote(&n); err != nil {
 		log.Printf("Error creating note: %v", err)
 		http.Error(w, err.Err, err.StatusCode)
+		return
 	}
 	bytes, mErr := json.Marshal(&n)
 	if err != nil {

--- a/samples/server/go-server/api/server/name/name.go
+++ b/samples/server/go-server/api/server/name/name.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/grafeas/grafeas/samples/server/go-server/api/server/errors"
+	"github.com/grafeas/grafeas/server-go/errors"
 )
 
 // ResourceKind is the type that will be used for all public resource kinds.

--- a/samples/server/go-server/api/server/storage/memstore.go
+++ b/samples/server/go-server/api/server/storage/memstore.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 
 	"github.com/grafeas/grafeas/samples/server/go-server/api"
-	"github.com/grafeas/grafeas/samples/server/go-server/api/server/errors"
 	"github.com/grafeas/grafeas/samples/server/go-server/api/server/name"
 	"github.com/grafeas/grafeas/server-go"
+	"github.com/grafeas/grafeas/server-go/errors"
 )
 
 // memStore is an in-memory storage solution for Grafeas

--- a/samples/server/go-server/api/server/v1alpha1/impl.go
+++ b/samples/server/go-server/api/server/v1alpha1/impl.go
@@ -21,9 +21,9 @@ import (
 	"net/http"
 
 	"github.com/grafeas/grafeas/samples/server/go-server/api"
-	"github.com/grafeas/grafeas/samples/server/go-server/api/server/errors"
 	"github.com/grafeas/grafeas/samples/server/go-server/api/server/name"
 	server "github.com/grafeas/grafeas/server-go"
+	"github.com/grafeas/grafeas/server-go/errors"
 )
 
 // Grafeas is an implementation of the Grafeas API, which should be called by handler methods for verification of logic
@@ -80,13 +80,13 @@ func (g *Grafeas) DeleteOccurrence(pID, oID string) *errors.AppError {
 
 // DeleteNote deletes a note from the datastore.
 func (g *Grafeas) DeleteNote(pID, nID string) *errors.AppError {
-	// TODO: Check for occurrences tied to this note, and return an error if there are any before deletion.
+	// TODO: Check for occurrences tied to this note, and return an *errors.AppError if there are any before deletion.
 	return g.S.DeleteNote(pID, nID)
 }
 
 // DeleteOperation deletes an operation from the datastore.
 func (g *Grafeas) DeleteOperation(pID, nID string) *errors.AppError {
-	// TODO: Check for occurrences and notes tied to this operation, and return an error if there are any before deletion.
+	// TODO: Check for occurrences and notes tied to this operation, and return an *errors.AppError if there are any before deletion.
 	return g.S.DeleteOperation(pID, nID)
 }
 

--- a/server-go/errors/errors.go
+++ b/server-go/errors/errors.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+// AppError conveys statused errors
+type AppError struct {
+	Err        string
+	StatusCode int
+}
+
+// Error is the consolidated error message output for an AppError and satisfies
+// the builtin error interface.
+func (e AppError) Error() string {
+	return fmt.Sprintf("[%d] %s", e.StatusCode, e.Err)
+}

--- a/server-go/storage.go
+++ b/server-go/storage.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"github.com/grafeas/grafeas/samples/server/go-server/api"
-	"github.com/grafeas/grafeas/samples/server/go-server/api/server/errors"
+	"github.com/grafeas/grafeas/server-go/errors"
 )
 
 // Storager is the interface that a Grafeas storage implementation would provide


### PR DESCRIPTION
Also have AppError satisfy the builtin errors so it can be bubbled up.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>