### PR TITLE
Add missing AttestationAuthority and Occurrence types

### DIFF
--- a/samples/server/go-server/api/note.go
+++ b/samples/server/go-server/api/note.go
@@ -37,6 +37,9 @@ type Note struct {
 	// This explicitly denotes which kind of note is specified. This field can be used as a filter in list requests. @OutputOnly
 	Kind string `json:"kind,omitempty"`
 
+	// A note describing a logical attestation.
+	AttestationAuthority AttestationAuthority `json:"attestationAuthority,omitempty"`
+
 	// A package vulnerability type of note.
 	VulnerabilityType VulnerabilityType `json:"vulnerabilityType,omitempty"`
 

--- a/samples/server/go-server/api/occurrence.go
+++ b/samples/server/go-server/api/occurrence.go
@@ -37,6 +37,9 @@ type Occurrence struct {
 	// This explicitly denotes which of the occurrence details is specified. This field can be used as a filter in list requests. @OutputOnly
 	Kind string `json:"kind,omitempty"`
 
+	// Describes an attestation.
+	Attestation Attestation `json:"attestation,omitempty"`
+
 	// Details of the custom note.
 	CustomDetails CustomDetails `json:"customDetails,omitempty"`
 


### PR DESCRIPTION
The sample Grafeas server no longer ignores the AttestationAuthority
type when creating Note objects or the Attestation type when creating
Occurrence objects.