### PR TITLE
Makefile: target is in wrong directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 vet:
 	@go tool vet ${SRC}
 
-model-go/v1alpha1/proto/grafeas.pb.go: .install.protoc-gen-go v1alpha1/proto/grafeas.proto
+v1alpha1/proto/grafeas.pb.go: .install.protoc-gen-go v1alpha1/proto/grafeas.proto
 	protoc \
 		-I ./ \
 		-I vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
@@ -33,7 +33,7 @@ model-go/v1alpha1/proto/grafeas.pb.go: .install.protoc-gen-go v1alpha1/proto/gra
 		v1alpha1/proto/grafeas.proto
 
 .PHONY: grafeas_go
-grafeas_go: model-go/v1alpha1/proto/grafeas.pb.go
+grafeas_go: v1alpha1/proto/grafeas.pb.go
 
 clean:
 	go clean ./...


### PR DESCRIPTION
generated pb.go is not in ./model-go/

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>