### PR TITLE
Copy local files instead of go get:ing in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.9
-RUN go get github.com/grafeas/grafeas/samples/server/go-server/api/server
+COPY . /go/src/github.com/grafeas/grafeas/
 WORKDIR /go/src/github.com/grafeas/grafeas/samples/server/go-server/api/server/main
 RUN CGO_ENABLED=0 go build -o grafeas-server .
 


### PR DESCRIPTION
I propose that the Dockerfile uses local source files instead of go get:ing them from the official repo. This makes it easier to build docker images during development and in forks.

Note that the Dockerfile was moved as well to allow docker to access the complete source tree.

CC @lizrice 