### PR TITLE
Pagination support (NOT READY TO MERGE)

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -39,3 +39,7 @@ grafeas:
     # Valid sslmodes disable, allow, prefer, require, verify-ca, verify-full.
     # See https://www.postgresql.org/docs/current/static/libpq-connect.html for details
     sslmode: "require"
+    # 32-bit URL-safe base64 key used to encrypt pagination tokens
+    # If one is not provided, it will be generated.
+    # Multiple grafeas instances in the same cluster need the same value.
+    paginationkey:

--- a/samples/server/go-server/api/server/storage/memstore.go
+++ b/samples/server/go-server/api/server/storage/memstore.go
@@ -94,7 +94,7 @@ func (m *memStore) ListProjects(filter string, pageSize int, pageToken string) (
 	sort.Slice(projects, func(i, j int) bool {
 		return projects[i].Name < projects[j].Name
 	})
-	startPos, endPos, err := calcRange(pageSize, pageToken, len(m.projects))
+	startPos, endPos, err := calcRange(pageSize, pageToken, len(projects))
 	if err != nil {
 		return nil, "", err
 	}
@@ -159,7 +159,14 @@ func (m *memStore) ListOccurrences(pID, filters string, pageSize int, pageToken 
 			os = append(os, o)
 		}
 	}
-	return os, "", nil
+	sort.Slice(os, func(i, j int) bool {
+		return os[i].Name < os[j].Name
+	})
+	startPos, endPos, err := calcRange(pageSize, pageToken, len(os))
+	if err != nil {
+		return nil, "", err
+	}
+	return os[startPos:endPos], strconv.Itoa(endPos), nil
 }
 
 // CreateNote adds the specified note to the mem store

--- a/samples/server/go-server/api/server/storage/memstore.go
+++ b/samples/server/go-server/api/server/storage/memstore.go
@@ -270,7 +270,14 @@ func (m *memStore) ListNoteOccurrences(pID, nID, filters string, pageSize int, p
 			os = append(os, o)
 		}
 	}
-	return os, "", nil
+	sort.Slice(os, func(i, j int) bool {
+		return os[i].Name < os[j].Name
+	})
+	startPos, endPos, err := calcRange(pageSize, pageToken, len(os))
+	if err != nil {
+		return nil, "", err
+	}
+	return os[startPos:endPos], strconv.Itoa(endPos), nil
 }
 
 // GetOperation returns the operation with pID and oID

--- a/samples/server/go-server/api/server/storage/memstore.go
+++ b/samples/server/go-server/api/server/storage/memstore.go
@@ -148,8 +148,9 @@ func (m *memStore) GetOccurrence(pID, oID string) (*pb.Occurrence, error) {
 	return o, nil
 }
 
-// ListOccurrences returns the occurrences for this project ID (pID)
-func (m *memStore) ListOccurrences(pID, filters string) ([]*pb.Occurrence, error) {
+// ListOccurrences returns up to pageSize number of occurrences for this project (pID) beginning
+// at pageToken (or from start if pageToken is the emtpy string).
+func (m *memStore) ListOccurrences(pID, filters string, pageSize int, pageToken string) ([]*pb.Occurrence, string, error) {
 	os := []*pb.Occurrence{}
 	m.RLock()
 	defer m.RUnlock()
@@ -158,7 +159,7 @@ func (m *memStore) ListOccurrences(pID, filters string) ([]*pb.Occurrence, error
 			os = append(os, o)
 		}
 	}
-	return os, nil
+	return os, "", nil
 }
 
 // CreateNote adds the specified note to the mem store
@@ -224,8 +225,9 @@ func (m *memStore) GetNoteByOccurrence(pID, oID string) (*pb.Note, error) {
 	return n, nil
 }
 
-// ListNotes returns the notes for for this project (pID)
-func (m *memStore) ListNotes(pID, filters string) ([]*pb.Note, error) {
+// ListNotes returns up to pageSize number of notes for this project (pID) beginning
+// at pageToken (or from start if pageToken is the emtpy string).
+func (m *memStore) ListNotes(pID, filters string, pageSize int, pageToken string) ([]*pb.Note, string, error) {
 	ns := []*pb.Note{}
 	m.RLock()
 	defer m.RUnlock()
@@ -234,17 +236,18 @@ func (m *memStore) ListNotes(pID, filters string) ([]*pb.Note, error) {
 			ns = append(ns, n)
 		}
 	}
-	return ns, nil
+	return ns, "", nil
 }
 
-// ListNoteOccurrences returns the occcurrences on the particular note (nID) for this project (pID)
-func (m *memStore) ListNoteOccurrences(pID, nID, filters string) ([]*pb.Occurrence, error) {
+// ListNoteOccurrences returns up to pageSize number of occcurrences on the particular note (nID)
+// for this project (pID) projects beginning at pageToken (or from start if pageToken is the emtpy string).
+func (m *memStore) ListNoteOccurrences(pID, nID, filters string, pageSize int, pageToken string) ([]*pb.Occurrence, string, error) {
 	// TODO: use filters
 	m.RLock()
 	defer m.RUnlock()
 	// Verify that note exists
 	if _, err := m.GetNote(pID, nID); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	nName := name.FormatNote(pID, nID)
 	os := []*pb.Occurrence{}
@@ -253,7 +256,7 @@ func (m *memStore) ListNoteOccurrences(pID, nID, filters string) ([]*pb.Occurren
 			os = append(os, o)
 		}
 	}
-	return os, nil
+	return os, "", nil
 }
 
 // GetOperation returns the operation with pID and oID

--- a/samples/server/go-server/api/server/storage/memstore.go
+++ b/samples/server/go-server/api/server/storage/memstore.go
@@ -314,7 +314,14 @@ func (m *memStore) ListOperations(pID, filters string, pageSize int, pageToken s
 			ops = append(ops, op)
 		}
 	}
-	return ops, "", nil
+	sort.Slice(ops, func(i, j int) bool {
+		return ops[i].Name < ops[j].Name
+	})
+	startPos, endPos, err := calcRange(pageSize, pageToken, len(ops))
+	if err != nil {
+		return nil, "", err
+	}
+	return ops[startPos:endPos], strconv.Itoa(endPos), nil
 }
 
 // Calculates start and end positions given the provided constraints

--- a/samples/server/go-server/api/server/storage/memstore.go
+++ b/samples/server/go-server/api/server/storage/memstore.go
@@ -303,8 +303,9 @@ func (m *memStore) UpdateOperation(pID, opID string, op *opspb.Operation) error 
 	return nil
 }
 
-// ListOperations returns the operations for this project (pID)
-func (m *memStore) ListOperations(pID, filters string) ([]*opspb.Operation, error) {
+// ListOperations returns up to pageSize number of operations for this project (pID) beginning
+// at pageToken (or from start if pageToken is the emtpy string).
+func (m *memStore) ListOperations(pID, filters string, pageSize int, pageToken string) ([]*opspb.Operation, string, error) {
 	ops := []*opspb.Operation{}
 	m.RLock()
 	defer m.RUnlock()
@@ -313,7 +314,7 @@ func (m *memStore) ListOperations(pID, filters string) ([]*opspb.Operation, erro
 			ops = append(ops, op)
 		}
 	}
-	return ops, nil
+	return ops, "", nil
 }
 
 // Calculates start and end positions given the provided constraints

--- a/samples/server/go-server/api/server/storage/memstore.go
+++ b/samples/server/go-server/api/server/storage/memstore.go
@@ -243,7 +243,14 @@ func (m *memStore) ListNotes(pID, filters string, pageSize int, pageToken string
 			ns = append(ns, n)
 		}
 	}
-	return ns, "", nil
+	sort.Slice(ns, func(i, j int) bool {
+		return ns[i].Name < ns[j].Name
+	})
+	startPos, endPos, err := calcRange(pageSize, pageToken, len(ns))
+	if err != nil {
+		return nil, "", err
+	}
+	return ns[startPos:endPos], strconv.Itoa(endPos), nil
 }
 
 // ListNoteOccurrences returns up to pageSize number of occcurrences on the particular note (nID)

--- a/samples/server/go-server/api/server/storage/pgsqlconfig.go
+++ b/samples/server/go-server/api/server/storage/pgsqlconfig.go
@@ -23,7 +23,8 @@ type PgSQLConfig struct {
 	Password string `yaml:"password"`
 	// Valid sslmodes: disable, allow, prefer, require, verify-ca, verify-full.
 	// See https://www.postgresql.org/docs/current/static/libpq-connect.html for details
-	SSLMode string `yaml:"sslmode"`
+	SSLMode       string `yaml:"sslmode"`
+	PaginationKey string `yaml:"paginationkey"`
 }
 
 func createSourceString(config *PgSQLConfig) string {

--- a/samples/server/go-server/api/server/storage/pgsqlstore.go
+++ b/samples/server/go-server/api/server/storage/pgsqlstore.go
@@ -25,7 +25,6 @@ import (
 	"github.com/fernet/fernet-go"
 	"github.com/golang/protobuf/proto"
 	"github.com/grafeas/grafeas/samples/server/go-server/api/server/name"
-	server "github.com/grafeas/grafeas/server-go"
 	pb "github.com/grafeas/grafeas/v1alpha1/proto"
 	"github.com/lib/pq"
 	opspb "google.golang.org/genproto/googleapis/longrunning"
@@ -133,14 +132,15 @@ func (pg *pgSQLStore) GetProject(pID string) (*pb.Project, error) {
 
 var paginationKey = "XxoPtCUzrUv4JV5dS+yQ+MdW7yLEJnRMwigVY/bpgtQ="
 
-// ListProjects returns the project id for all projects from the store
-func (pg *pgSQLStore) ListProjects(options *server.ListOptions) ([]*pb.Project, string, error) {
+// ListProjects returns up to pageSize number of projects beginning at pageToken (or from
+// start if pageToken is the emtpy string).
+func (pg *pgSQLStore) ListProjects(filter string, pageSize int, pageToken string) ([]*pb.Project, string, error) {
 	var rows *sql.Rows
-	id, err := decryptInt64(options.PageToken, paginationKey)
+	id, err := decryptInt64(pageToken, paginationKey)
 	if err == nil {
-		rows, err = pg.DB.Query(listProjectsFromPage, options.PageSize, id)
+		rows, err = pg.DB.Query(listProjectsFromPage, pageSize, id)
 	} else {
-		rows, err = pg.DB.Query(listProjects, options.PageSize)
+		rows, err = pg.DB.Query(listProjects, pageSize)
 	}
 	if err != nil {
 		return nil, "", status.Error(codes.Unknown, "Failed to list Projects from database")

--- a/samples/server/go-server/api/server/storage/pgsqlstore.go
+++ b/samples/server/go-server/api/server/storage/pgsqlstore.go
@@ -520,7 +520,10 @@ func (pg *pgSQLStore) ListOperations(pID, filters string, pageSize int, pageToke
 
 // Encrypt int64 using provided key
 func encryptInt64(v int64, key string) (string, error) {
-	k, _ := fernet.DecodeKey(key)
+	k, err := fernet.DecodeKey(key)
+	if err != nil {
+		return "", err
+	}
 	bytes, err := fernet.EncryptAndSign([]byte(strconv.FormatInt(v, 10)), k)
 	if err != nil {
 		return "", err
@@ -530,7 +533,10 @@ func encryptInt64(v int64, key string) (string, error) {
 
 // Decrypts encrypted int64 using provided key
 func decryptInt64(encrypted string, key string) (int64, error) {
-	k, _ := fernet.DecodeKey(key)
+	k, err := fernet.DecodeKey(key)
+	if err != nil {
+		return 0, err
+	}
 	bytes := fernet.VerifyAndDecrypt([]byte(encrypted), time.Hour, []*fernet.Key{k})
 	if bytes == nil {
 		return 0, errors.New("invalid or expired pagination token")

--- a/samples/server/go-server/api/server/storage/pgsqlstore.go
+++ b/samples/server/go-server/api/server/storage/pgsqlstore.go
@@ -96,7 +96,7 @@ func (pg *pgSQLStore) CreateProject(pID string) error {
 			return status.Error(codes.AlreadyExists, fmt.Sprintf("Project with name %q already exists", pID))
 		} else {
 			log.Println("Failed to insert Project in database", err)
-			return status.Error(codes.Unknown, fmt.Sprintf("Failed to insert Project in database"))
+			return status.Error(codes.Internal, "Failed to insert Project in database")
 		}
 	}
 	return nil
@@ -107,11 +107,11 @@ func (pg *pgSQLStore) DeleteProject(pID string) error {
 	pName := name.FormatProject(pID)
 	result, err := pg.DB.Exec(deleteProject, pName)
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to delete Project from database"))
+		return status.Error(codes.Internal, "Failed to delete Project from database")
 	}
 	count, err := result.RowsAffected()
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to delete Project from database"))
+		return status.Error(codes.Internal, "Failed to delete Project from database")
 	}
 	if count == 0 {
 		return status.Error(codes.NotFound, fmt.Sprintf("Project with name %q does not Exist", pName))
@@ -125,7 +125,7 @@ func (pg *pgSQLStore) GetProject(pID string) (*pb.Project, error) {
 	var exists bool
 	err := pg.DB.QueryRow(projectExists, pName).Scan(&exists)
 	if err != nil {
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to query Project from database"))
+		return nil, status.Error(codes.Internal, "Failed to query Project from database")
 	}
 	if !exists {
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("Project with name %q does not Exist", pName))
@@ -144,7 +144,7 @@ func (pg *pgSQLStore) ListProjects(filter string, pageSize int, pageToken string
 		rows, err = pg.DB.Query(listProjects, pageSize)
 	}
 	if err != nil {
-		return nil, "", status.Error(codes.Unknown, "Failed to list Projects from database")
+		return nil, "", status.Error(codes.Internal, "Failed to list Projects from database")
 	}
 	var projects []*pb.Project
 	var lastId int64
@@ -152,13 +152,13 @@ func (pg *pgSQLStore) ListProjects(filter string, pageSize int, pageToken string
 		var name string
 		err := rows.Scan(&lastId, &name)
 		if err != nil {
-			return nil, "", status.Error(codes.Unknown, "Failed to scan Project row")
+			return nil, "", status.Error(codes.Internal, "Failed to scan Project row")
 		}
 		projects = append(projects, &pb.Project{Name: name})
 	}
 	encryptedPage, err := encryptInt64(lastId, pg.paginationKey)
 	if err != nil {
-		return nil, "", status.Error(codes.Unknown, "Failed to paginate projects")
+		return nil, "", status.Error(codes.Internal, "Failed to paginate projects")
 	}
 	return projects, encryptedPage, nil
 }
@@ -182,7 +182,7 @@ func (pg *pgSQLStore) CreateOccurrence(o *pb.Occurrence) error {
 			return status.Error(codes.AlreadyExists, fmt.Sprintf("Occurrence with name %q already exists", o.Name))
 		} else {
 			log.Println("Failed to insert Occurrence in database", err)
-			return status.Error(codes.Unknown, fmt.Sprintf("Failed to insert Occurrence in database"))
+			return status.Error(codes.Internal, "Failed to insert Occurrence in database")
 		}
 	}
 	return nil
@@ -192,11 +192,11 @@ func (pg *pgSQLStore) CreateOccurrence(o *pb.Occurrence) error {
 func (pg *pgSQLStore) DeleteOccurrence(pID, oID string) error {
 	result, err := pg.DB.Exec(deleteOccurrence, pID, oID)
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to delete Occurrence from database"))
+		return status.Error(codes.Internal, "Failed to delete Occurrence from database")
 	}
 	count, err := result.RowsAffected()
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to delete Occurrence from database"))
+		return status.Error(codes.Internal, "Failed to delete Occurrence from database")
 	}
 	if count == 0 {
 		return status.Error(codes.NotFound, fmt.Sprintf("Occurrence with name %q/%q does not Exist", pID, oID))
@@ -208,11 +208,11 @@ func (pg *pgSQLStore) DeleteOccurrence(pID, oID string) error {
 func (pg *pgSQLStore) UpdateOccurrence(pID, oID string, o *pb.Occurrence) error {
 	result, err := pg.DB.Exec(updateOccurrence, pID, oID, proto.MarshalTextString(o))
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to update Occurrence"))
+		return status.Error(codes.Internal, "Failed to update Occurrence")
 	}
 	count, err := result.RowsAffected()
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to update Occurrence"))
+		return status.Error(codes.Internal, "Failed to update Occurrence")
 	}
 	if count == 0 {
 		return status.Error(codes.NotFound, fmt.Sprintf("Occurrence with name %q/%q does not Exist", pID, oID))
@@ -228,12 +228,12 @@ func (pg *pgSQLStore) GetOccurrence(pID, oID string) (*pb.Occurrence, error) {
 	case err == sql.ErrNoRows:
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("Occurrence with name %q/%q does not Exist", pID, oID))
 	case err != nil:
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to query Occurrence from database"))
+		return nil, status.Error(codes.Internal, "Failed to query Occurrence from database")
 	}
 	var o pb.Occurrence
 	proto.UnmarshalText(data, &o)
 	if err != nil {
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to unmarshal Occurrence from database"))
+		return nil, status.Error(codes.Internal, "Failed to unmarshal Occurrence from database")
 	}
 	return &o, nil
 }
@@ -249,7 +249,7 @@ func (pg *pgSQLStore) ListOccurrences(pID, filters string, pageSize int, pageTok
 		rows, err = pg.DB.Query(listOccurrences, pID, pageSize)
 	}
 	if err != nil {
-		return nil, "", status.Error(codes.Unknown, "Failed to list Occurrences from database")
+		return nil, "", status.Error(codes.Internal, "Failed to list Occurrences from database")
 	}
 	os := []*pb.Occurrence{}
 	var lastId int64
@@ -257,18 +257,18 @@ func (pg *pgSQLStore) ListOccurrences(pID, filters string, pageSize int, pageTok
 		var data string
 		err := rows.Scan(&lastId, &data)
 		if err != nil {
-			return nil, "", status.Error(codes.Unknown, "Failed to scan Occurrences row")
+			return nil, "", status.Error(codes.Internal, "Failed to scan Occurrences row")
 		}
 		var o pb.Occurrence
 		proto.UnmarshalText(data, &o)
 		if err != nil {
-			return nil, "", status.Error(codes.Unknown, "Failed to unmarshal Occurrence from database")
+			return nil, "", status.Error(codes.Internal, "Failed to unmarshal Occurrence from database")
 		}
 		os = append(os, &o)
 	}
 	encryptedPage, err := encryptInt64(lastId, pg.paginationKey)
 	if err != nil {
-		return nil, "", status.Error(codes.Unknown, "Failed to paginate projects")
+		return nil, "", status.Error(codes.Internal, "Failed to paginate projects")
 	}
 	return os, encryptedPage, nil
 }
@@ -287,7 +287,7 @@ func (pg *pgSQLStore) CreateNote(n *pb.Note) error {
 			return status.Error(codes.AlreadyExists, fmt.Sprintf("Note with name %q already exists", n.Name))
 		} else {
 			log.Println("Failed to insert Note in database", err)
-			return status.Error(codes.Unknown, fmt.Sprintf("Failed to insert Note in database"))
+			return status.Error(codes.Internal, "Failed to insert Note in database")
 		}
 	}
 	return nil
@@ -297,11 +297,11 @@ func (pg *pgSQLStore) CreateNote(n *pb.Note) error {
 func (pg *pgSQLStore) DeleteNote(pID, nID string) error {
 	result, err := pg.DB.Exec(deleteNote, pID, nID)
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to delete Note from database"))
+		return status.Error(codes.Internal, "Failed to delete Note from database")
 	}
 	count, err := result.RowsAffected()
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to delete Note from database"))
+		return status.Error(codes.Internal, "Failed to delete Note from database")
 	}
 	if count == 0 {
 		return status.Error(codes.NotFound, fmt.Sprintf("Note with name %q/%q does not Exist", pID, nID))
@@ -313,11 +313,11 @@ func (pg *pgSQLStore) DeleteNote(pID, nID string) error {
 func (pg *pgSQLStore) UpdateNote(pID, nID string, n *pb.Note) error {
 	result, err := pg.DB.Exec(updateNote, pID, nID, proto.MarshalTextString(n))
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to update Note"))
+		return status.Error(codes.Internal, "Failed to update Note")
 	}
 	count, err := result.RowsAffected()
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to update Note"))
+		return status.Error(codes.Internal, "Failed to update Note")
 	}
 	if count == 0 {
 		return status.Error(codes.NotFound, fmt.Sprintf("Note with name %q/%q does not Exist", pID, nID))
@@ -333,12 +333,12 @@ func (pg *pgSQLStore) GetNote(pID, nID string) (*pb.Note, error) {
 	case err == sql.ErrNoRows:
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("Note with name %q/%q does not Exist", pID, nID))
 	case err != nil:
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to query Note from database"))
+		return nil, status.Error(codes.Internal, "Failed to query Note from database")
 	}
 	var note pb.Note
 	proto.UnmarshalText(data, &note)
 	if err != nil {
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to unmarshal Note from database"))
+		return nil, status.Error(codes.Internal, "Failed to unmarshal Note from database")
 	}
 	return &note, nil
 }
@@ -366,19 +366,19 @@ func (pg *pgSQLStore) GetNoteByOccurrence(pID, oID string) (*pb.Note, error) {
 func (pg *pgSQLStore) ListNotes(pID, filters string, pageSize int, pageToken string) ([]*pb.Note, string, error) {
 	rows, err := pg.DB.Query(listNotes, pID)
 	if err != nil {
-		return nil, "", status.Error(codes.Unknown, "Failed to list Notes from database")
+		return nil, "", status.Error(codes.Internal, "Failed to list Notes from database")
 	}
 	ns := []*pb.Note{}
 	for rows.Next() {
 		var data string
 		err := rows.Scan(&data)
 		if err != nil {
-			return nil, "", status.Error(codes.Unknown, "Failed to scan Notes row")
+			return nil, "", status.Error(codes.Internal, "Failed to scan Notes row")
 		}
 		var n pb.Note
 		proto.UnmarshalText(data, &n)
 		if err != nil {
-			return nil, "", status.Error(codes.Unknown, "Failed to unmarshal Note from database")
+			return nil, "", status.Error(codes.Internal, "Failed to unmarshal Note from database")
 		}
 		ns = append(ns, &n)
 	}
@@ -394,19 +394,19 @@ func (pg *pgSQLStore) ListNoteOccurrences(pID, nID, filters string, pageSize int
 	}
 	rows, err := pg.DB.Query(listNoteOccurrences, pID, nID)
 	if err != nil {
-		return nil, "", status.Error(codes.Unknown, "Failed to list Occurrences from database")
+		return nil, "", status.Error(codes.Internal, "Failed to list Occurrences from database")
 	}
 	os := []*pb.Occurrence{}
 	for rows.Next() {
 		var data string
 		err := rows.Scan(&data)
 		if err != nil {
-			return nil, "", status.Error(codes.Unknown, "Failed to scan Occurrences row")
+			return nil, "", status.Error(codes.Internal, "Failed to scan Occurrences row")
 		}
 		var o pb.Occurrence
 		proto.UnmarshalText(data, &o)
 		if err != nil {
-			return nil, "", status.Error(codes.Unknown, "Failed to unmarshal Occurrence from database")
+			return nil, "", status.Error(codes.Internal, "Failed to unmarshal Occurrence from database")
 		}
 		os = append(os, &o)
 	}
@@ -421,12 +421,12 @@ func (pg *pgSQLStore) GetOperation(pID, opID string) (*opspb.Operation, error) {
 	case err == sql.ErrNoRows:
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("Operation with name %q/%q does not Exist", pID, opID))
 	case err != nil:
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to query Operation from database"))
+		return nil, status.Error(codes.Internal, "Failed to query Operation from database")
 	}
 	var op opspb.Operation
 	proto.UnmarshalText(data, &op)
 	if err != nil {
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to unmarshal Operation from database"))
+		return nil, status.Error(codes.Internal, "Failed to unmarshal Operation from database")
 	}
 	return &op, nil
 }
@@ -445,7 +445,7 @@ func (pg *pgSQLStore) CreateOperation(o *opspb.Operation) error {
 			return status.Error(codes.AlreadyExists, fmt.Sprintf("Operation with name %q/%q already exists", pID, opID))
 		} else {
 			log.Println("Failed to insert Operation in database", err)
-			return status.Error(codes.Unknown, fmt.Sprintf("Failed to insert Operation in database"))
+			return status.Error(codes.Internal, "Failed to insert Operation in database")
 		}
 	}
 	return nil
@@ -455,11 +455,11 @@ func (pg *pgSQLStore) CreateOperation(o *opspb.Operation) error {
 func (pg *pgSQLStore) DeleteOperation(pID, opID string) error {
 	result, err := pg.DB.Exec(deleteOperation, pID, opID)
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to delete Operation from database"))
+		return status.Error(codes.Internal, "Failed to delete Operation from database")
 	}
 	count, err := result.RowsAffected()
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to delete Operation from database"))
+		return status.Error(codes.Internal, "Failed to delete Operation from database")
 	}
 	if count == 0 {
 		return status.Error(codes.NotFound, fmt.Sprintf("Operation with name %q/%q does not Exist", pID, opID))
@@ -471,11 +471,11 @@ func (pg *pgSQLStore) DeleteOperation(pID, opID string) error {
 func (pg *pgSQLStore) UpdateOperation(pID, opID string, op *opspb.Operation) error {
 	result, err := pg.DB.Exec(updateOperation, pID, opID, proto.MarshalTextString(op))
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to update Operation"))
+		return status.Error(codes.Internal, "Failed to update Operation")
 	}
 	count, err := result.RowsAffected()
 	if err != nil {
-		return status.Error(codes.Unknown, fmt.Sprintf("Failed to update Operation"))
+		return status.Error(codes.Internal, "Failed to update Operation")
 	}
 	if count == 0 {
 		return status.Error(codes.NotFound, fmt.Sprintf("Operation with name %q/%q does not Exist", pID, opID))
@@ -494,7 +494,7 @@ func (pg *pgSQLStore) ListOperations(pID, filters string, pageSize int, pageToke
 		rows, err = pg.DB.Query(listOperations, pID, pageSize)
 	}
 	if err != nil {
-		return nil, "", status.Error(codes.Unknown, "Failed to list Operations from database")
+		return nil, "", status.Error(codes.Internal, "Failed to list Operations from database")
 	}
 	ops := []*opspb.Operation{}
 	var lastId int64
@@ -502,18 +502,18 @@ func (pg *pgSQLStore) ListOperations(pID, filters string, pageSize int, pageToke
 		var data string
 		err := rows.Scan(&lastId, &data)
 		if err != nil {
-			return nil, "", status.Error(codes.Unknown, "Failed to scan Operations row")
+			return nil, "", status.Error(codes.Internal, "Failed to scan Operations row")
 		}
 		var op opspb.Operation
 		proto.UnmarshalText(data, &op)
 		if err != nil {
-			return nil, "", status.Error(codes.Unknown, "Failed to unmarshal Operation from database")
+			return nil, "", status.Error(codes.Internal, "Failed to unmarshal Operation from database")
 		}
 		ops = append(ops, &op)
 	}
 	encryptedPage, err := encryptInt64(lastId, pg.paginationKey)
 	if err != nil {
-		return nil, "", status.Error(codes.Unknown, "Failed to paginate projects")
+		return nil, "", status.Error(codes.Internal, "Failed to paginate projects")
 	}
 	return ops, encryptedPage, nil
 }

--- a/samples/server/go-server/api/server/storage/pgsqlstore.go
+++ b/samples/server/go-server/api/server/storage/pgsqlstore.go
@@ -237,27 +237,28 @@ func (pg *pgSQLStore) GetOccurrence(pID, oID string) (*pb.Occurrence, error) {
 	return &o, nil
 }
 
-// ListOccurrences returns the occurrences for this project ID (pID)
-func (pg *pgSQLStore) ListOccurrences(pID, filters string) ([]*pb.Occurrence, error) {
+// ListOccurrences returns up to pageSize number of occurrences for this project (pID) beginning
+// at pageToken (or from start if pageToken is the emtpy string).
+func (pg *pgSQLStore) ListOccurrences(pID, filters string, pageSize int, pageToken string) ([]*pb.Occurrence, string, error) {
 	rows, err := pg.DB.Query(listOccurrences, pID)
 	if err != nil {
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to list Occurrences from database"))
+		return nil, "", status.Error(codes.Unknown, "Failed to list Occurrences from database")
 	}
 	os := []*pb.Occurrence{}
 	for rows.Next() {
 		var data string
 		err := rows.Scan(&data)
 		if err != nil {
-			return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to scan Occurrences row"))
+			return nil, "", status.Error(codes.Unknown, "Failed to scan Occurrences row")
 		}
 		var o pb.Occurrence
 		proto.UnmarshalText(data, &o)
 		if err != nil {
-			return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to unmarshal Occurrence from database"))
+			return nil, "", status.Error(codes.Unknown, "Failed to unmarshal Occurrence from database")
 		}
 		os = append(os, &o)
 	}
-	return os, nil
+	return os, "", nil
 }
 
 // CreateNote adds the specified note
@@ -348,54 +349,56 @@ func (pg *pgSQLStore) GetNoteByOccurrence(pID, oID string) (*pb.Note, error) {
 	return n, nil
 }
 
-// ListNotes returns the notes for for this project (pID)
-func (pg *pgSQLStore) ListNotes(pID, filters string) ([]*pb.Note, error) {
+// ListNotes returns up to pageSize number of notes for this project (pID) beginning
+// at pageToken (or from start if pageToken is the emtpy string).
+func (pg *pgSQLStore) ListNotes(pID, filters string, pageSize int, pageToken string) ([]*pb.Note, string, error) {
 	rows, err := pg.DB.Query(listNotes, pID)
 	if err != nil {
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to list Notes from database"))
+		return nil, "", status.Error(codes.Unknown, "Failed to list Notes from database")
 	}
 	ns := []*pb.Note{}
 	for rows.Next() {
 		var data string
 		err := rows.Scan(&data)
 		if err != nil {
-			return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to scan Notes row"))
+			return nil, "", status.Error(codes.Unknown, "Failed to scan Notes row")
 		}
 		var n pb.Note
 		proto.UnmarshalText(data, &n)
 		if err != nil {
-			return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to unmarshal Note from database"))
+			return nil, "", status.Error(codes.Unknown, "Failed to unmarshal Note from database")
 		}
 		ns = append(ns, &n)
 	}
-	return ns, nil
+	return ns, "", nil
 }
 
-// ListNoteOccurrences returns the occcurrences on the particular note (nID) for this project (pID)
-func (pg *pgSQLStore) ListNoteOccurrences(pID, nID, filters string) ([]*pb.Occurrence, error) {
+// ListNoteOccurrences returns up to pageSize number of occcurrences on the particular note (nID)
+// for this project (pID) projects beginning at pageToken (or from start if pageToken is the emtpy string).
+func (pg *pgSQLStore) ListNoteOccurrences(pID, nID, filters string, pageSize int, pageToken string) ([]*pb.Occurrence, string, error) {
 	// Verify that note exists
 	if _, err := pg.GetNote(pID, nID); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	rows, err := pg.DB.Query(listNoteOccurrences, pID, nID)
 	if err != nil {
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to list Occurrences from database"))
+		return nil, "", status.Error(codes.Unknown, "Failed to list Occurrences from database")
 	}
 	os := []*pb.Occurrence{}
 	for rows.Next() {
 		var data string
 		err := rows.Scan(&data)
 		if err != nil {
-			return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to scan Occurrences row"))
+			return nil, "", status.Error(codes.Unknown, "Failed to scan Occurrences row")
 		}
 		var o pb.Occurrence
 		proto.UnmarshalText(data, &o)
 		if err != nil {
-			return nil, status.Error(codes.Unknown, fmt.Sprintf("Failed to unmarshal Occurrence from database"))
+			return nil, "", status.Error(codes.Unknown, "Failed to unmarshal Occurrence from database")
 		}
 		os = append(os, &o)
 	}
-	return os, nil
+	return os, "", nil
 }
 
 // GetOperation returns the operation with pID and oID

--- a/samples/server/go-server/api/server/storage/pgsqlstore_test.go
+++ b/samples/server/go-server/api/server/storage/pgsqlstore_test.go
@@ -46,11 +46,12 @@ func TestPgSQLStore(t *testing.T) {
 	createPgSQLStore := func(t *testing.T) (server.Storager, func()) {
 		t.Helper()
 		config := &PgSQLConfig{
-			Host:     "127.0.0.1:5432",
-			DbName:   "test_db",
-			User:     "postgres",
-			Password: "password",
-			SSLMode:  "disable",
+			Host:          "127.0.0.1:5432",
+			DbName:        "test_db",
+			User:          "postgres",
+			Password:      "password",
+			SSLMode:       "disable",
+			PaginationKey: "XxoPtCUzrUv4JV5dS+yQ+MdW7yLEJnRMwigVY/bpgtQ=",
 		}
 		pg := NewPgSQLStore(config)
 		return pg, func() { dropDatabase(t, config); pg.Close() }

--- a/samples/server/go-server/api/server/storage/queries.go
+++ b/samples/server/go-server/api/server/storage/queries.go
@@ -61,7 +61,8 @@ const (
 	searchNote          = `SELECT data FROM notes WHERE project_name = $1 AND note_name = $2`
 	updateNote          = `UPDATE notes SET data = $3 WHERE project_name = $1 AND note_name = $2`
 	deleteNote          = `DELETE FROM notes WHERE project_name = $1 AND note_name = $2`
-	listNotes           = `SELECT data FROM notes WHERE project_name = $1`
+	listNotes           = `SELECT id, data FROM notes WHERE project_name = $1 LIMIT $2`
+	listNotesFromPage   = `SELECT id, data FROM notes WHERE project_name = $1 AND id > $3 LIMIT $2`
 	listNoteOccurrences = `SELECT o.data FROM occurrences as o, notes as n
                            WHERE n.id = o.note_id
                              AND n.project_name = $1

--- a/samples/server/go-server/api/server/storage/queries.go
+++ b/samples/server/go-server/api/server/storage/queries.go
@@ -51,10 +51,11 @@ const (
 
 	insertOccurrence = `INSERT INTO occurrences(project_name, occurrence_name, note_id, data)
                       VALUES ($1, $2, (SELECT id FROM notes WHERE project_name = $3 AND note_name = $4), $5)`
-	searchOccurrence = `SELECT data FROM occurrences WHERE project_name = $1 AND occurrence_name = $2`
-	updateOccurrence = `UPDATE occurrences SET data = $3 WHERE project_name = $1 AND occurrence_name = $2`
-	deleteOccurrence = `DELETE FROM occurrences WHERE project_name = $1 AND occurrence_name = $2`
-	listOccurrences  = `SELECT data FROM occurrences WHERE project_name = $1`
+	searchOccurrence        = `SELECT data FROM occurrences WHERE project_name = $1 AND occurrence_name = $2`
+	updateOccurrence        = `UPDATE occurrences SET data = $3 WHERE project_name = $1 AND occurrence_name = $2`
+	deleteOccurrence        = `DELETE FROM occurrences WHERE project_name = $1 AND occurrence_name = $2`
+	listOccurrences         = `SELECT id, data FROM occurrences WHERE project_name = $1 LIMIT $2`
+	listOccurrencesFromPage = `SELECT id, data FROM occurrences WHERE project_name = $1 AND id > $3 LIMIT $2`
 
 	insertNote          = `INSERT INTO notes(project_name, note_name, data) VALUES ($1, $2, $3)`
 	searchNote          = `SELECT data FROM notes WHERE project_name = $1 AND note_name = $2`

--- a/samples/server/go-server/api/server/storage/queries.go
+++ b/samples/server/go-server/api/server/storage/queries.go
@@ -43,42 +43,33 @@ const (
 			UNIQUE (project_name, operation_name)
 		);`
 
-	insertProject        = `INSERT INTO projects(name) VALUES ($1)`
-	projectExists        = `SELECT EXISTS (SELECT 1 FROM projects WHERE name = $1)`
-	deleteProject        = `DELETE FROM projects WHERE name = $1`
-	listProjects         = `SELECT id, name FROM projects LIMIT $1`
-	listProjectsFromPage = `SELECT id, name FROM projects WHERE id > $2 LIMIT $1`
+	insertProject = `INSERT INTO projects(name) VALUES ($1)`
+	projectExists = `SELECT EXISTS (SELECT 1 FROM projects WHERE name = $1)`
+	deleteProject = `DELETE FROM projects WHERE name = $1`
+	listProjects  = `SELECT id, name FROM projects WHERE id > $2 LIMIT $1`
 
 	insertOccurrence = `INSERT INTO occurrences(project_name, occurrence_name, note_id, data)
                       VALUES ($1, $2, (SELECT id FROM notes WHERE project_name = $3 AND note_name = $4), $5)`
-	searchOccurrence        = `SELECT data FROM occurrences WHERE project_name = $1 AND occurrence_name = $2`
-	updateOccurrence        = `UPDATE occurrences SET data = $3 WHERE project_name = $1 AND occurrence_name = $2`
-	deleteOccurrence        = `DELETE FROM occurrences WHERE project_name = $1 AND occurrence_name = $2`
-	listOccurrences         = `SELECT id, data FROM occurrences WHERE project_name = $1 LIMIT $2`
-	listOccurrencesFromPage = `SELECT id, data FROM occurrences WHERE project_name = $1 AND id > $3 LIMIT $2`
+	searchOccurrence = `SELECT data FROM occurrences WHERE project_name = $1 AND occurrence_name = $2`
+	updateOccurrence = `UPDATE occurrences SET data = $3 WHERE project_name = $1 AND occurrence_name = $2`
+	deleteOccurrence = `DELETE FROM occurrences WHERE project_name = $1 AND occurrence_name = $2`
+	listOccurrences  = `SELECT id, data FROM occurrences WHERE project_name = $1 AND id > $3 LIMIT $2`
 
 	insertNote          = `INSERT INTO notes(project_name, note_name, data) VALUES ($1, $2, $3)`
 	searchNote          = `SELECT data FROM notes WHERE project_name = $1 AND note_name = $2`
 	updateNote          = `UPDATE notes SET data = $3 WHERE project_name = $1 AND note_name = $2`
 	deleteNote          = `DELETE FROM notes WHERE project_name = $1 AND note_name = $2`
-	listNotes           = `SELECT id, data FROM notes WHERE project_name = $1 LIMIT $2`
-	listNotesFromPage   = `SELECT id, data FROM notes WHERE project_name = $1 AND id > $3 LIMIT $2`
+	listNotes           = `SELECT id, data FROM notes WHERE project_name = $1 AND id > $3 LIMIT $2`
 	listNoteOccurrences = `SELECT o.id, o.data FROM occurrences as o, notes as n
-                           WHERE n.id = o.note_id
-                             AND n.project_name = $1
-                             AND n.note_name = $2
-                             LIMIT $3`
-	listNoteOccurrencesFromPage = `SELECT o.id, o.data FROM occurrences as o, notes as n
-                           WHERE n.id = o.note_id
-                             AND n.project_name = $1
-                             AND n.note_name = $2
-														 AND o.id > $4
-														 LIMIT $3`
+	                         WHERE n.id = o.note_id
+	                           AND n.project_name = $1
+	                           AND n.note_name = $2
+	                           AND o.id > $4
+	                           LIMIT $3`
 
-	insertOperation        = `INSERT INTO operations(project_name, operation_name, data) VALUES ($1, $2, $3)`
-	searchOperation        = `SELECT data FROM operations WHERE project_name = $1 AND operation_name = $2`
-	deleteOperation        = `DELETE FROM operations WHERE project_name = $1 AND operation_name = $2`
-	updateOperation        = `UPDATE operations SET data = $3 WHERE project_name = $1 AND operation_name = $2`
-	listOperations         = `SELECT id, data FROM operations WHERE project_name = $1 LIMIT $2`
-	listOperationsFromPage = `SELECT id, data FROM operations WHERE project_name = $1 AND id > $3 LIMIT $2`
+	insertOperation = `INSERT INTO operations(project_name, operation_name, data) VALUES ($1, $2, $3)`
+	searchOperation = `SELECT data FROM operations WHERE project_name = $1 AND operation_name = $2`
+	deleteOperation = `DELETE FROM operations WHERE project_name = $1 AND operation_name = $2`
+	updateOperation = `UPDATE operations SET data = $3 WHERE project_name = $1 AND operation_name = $2`
+	listOperations  = `SELECT id, data FROM operations WHERE project_name = $1 AND id > $3 LIMIT $2`
 )

--- a/samples/server/go-server/api/server/storage/queries.go
+++ b/samples/server/go-server/api/server/storage/queries.go
@@ -66,9 +66,10 @@ const (
                              AND n.project_name = $1
                              AND n.note_name = $2`
 
-	insertOperation = `INSERT INTO operations(project_name, operation_name, data) VALUES ($1, $2, $3)`
-	searchOperation = `SELECT data FROM operations WHERE project_name = $1 AND operation_name = $2`
-	deleteOperation = `DELETE FROM operations WHERE project_name = $1 AND operation_name = $2`
-	updateOperation = `UPDATE operations SET data = $3 WHERE project_name = $1 AND operation_name = $2`
-	listOperations  = `SELECT data FROM operations WHERE project_name = $1`
+	insertOperation        = `INSERT INTO operations(project_name, operation_name, data) VALUES ($1, $2, $3)`
+	searchOperation        = `SELECT data FROM operations WHERE project_name = $1 AND operation_name = $2`
+	deleteOperation        = `DELETE FROM operations WHERE project_name = $1 AND operation_name = $2`
+	updateOperation        = `UPDATE operations SET data = $3 WHERE project_name = $1 AND operation_name = $2`
+	listOperations         = `SELECT id, data FROM operations WHERE project_name = $1 LIMIT $2`
+	listOperationsFromPage = `SELECT id, data FROM operations WHERE project_name = $1 AND id > $3 LIMIT $2`
 )

--- a/samples/server/go-server/api/server/storage/queries.go
+++ b/samples/server/go-server/api/server/storage/queries.go
@@ -63,10 +63,17 @@ const (
 	deleteNote          = `DELETE FROM notes WHERE project_name = $1 AND note_name = $2`
 	listNotes           = `SELECT id, data FROM notes WHERE project_name = $1 LIMIT $2`
 	listNotesFromPage   = `SELECT id, data FROM notes WHERE project_name = $1 AND id > $3 LIMIT $2`
-	listNoteOccurrences = `SELECT o.data FROM occurrences as o, notes as n
+	listNoteOccurrences = `SELECT o.id, o.data FROM occurrences as o, notes as n
                            WHERE n.id = o.note_id
                              AND n.project_name = $1
-                             AND n.note_name = $2`
+                             AND n.note_name = $2
+                             LIMIT $3`
+	listNoteOccurrencesFromPage = `SELECT o.id, o.data FROM occurrences as o, notes as n
+                           WHERE n.id = o.note_id
+                             AND n.project_name = $1
+                             AND n.note_name = $2
+														 AND o.id > $4
+														 LIMIT $3`
 
 	insertOperation        = `INSERT INTO operations(project_name, operation_name, data) VALUES ($1, $2, $3)`
 	searchOperation        = `SELECT data FROM operations WHERE project_name = $1 AND operation_name = $2`

--- a/samples/server/go-server/api/server/storage/queries.go
+++ b/samples/server/go-server/api/server/storage/queries.go
@@ -43,10 +43,11 @@ const (
 			UNIQUE (project_name, operation_name)
 		);`
 
-	insertProject = `INSERT INTO projects(name) VALUES ($1)`
-	projectExists = `SELECT EXISTS (SELECT 1 FROM projects WHERE name = $1)`
-	deleteProject = `DELETE FROM projects WHERE name = $1`
-	listProjects  = `SELECT name FROM projects`
+	insertProject        = `INSERT INTO projects(name) VALUES ($1)`
+	projectExists        = `SELECT EXISTS (SELECT 1 FROM projects WHERE name = $1)`
+	deleteProject        = `DELETE FROM projects WHERE name = $1`
+	listProjects         = `SELECT id, name FROM projects LIMIT $1`
+	listProjectsFromPage = `SELECT id, name FROM projects WHERE id > $2 LIMIT $1`
 
 	insertOccurrence = `INSERT INTO occurrences(project_name, occurrence_name, note_id, data)
                       VALUES ($1, $2, (SELECT id FROM notes WHERE project_name = $3 AND note_name = $4), $5)`

--- a/samples/server/go-server/api/server/storage/storager_test.go
+++ b/samples/server/go-server/api/server/storage/storager_test.go
@@ -510,7 +510,7 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			}
 			ns = append(ns, n)
 		}
-		gotNs, err := s.ListNotes(findProject, "")
+		gotNs, _, err := s.ListNotes(findProject, "", 100, "")
 		if err != nil {
 			t.Fatalf("ListNotes got %v want success", err)
 		}
@@ -549,7 +549,7 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			}
 			os = append(os, o)
 		}
-		gotOs, err := s.ListOccurrences(findProject, "")
+		gotOs, _, err := s.ListOccurrences(findProject, "", 100, "")
 		if err != nil {
 			t.Fatalf("ListOccurrences got %v want success", err)
 		}
@@ -592,7 +592,7 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 		if err != nil {
 			t.Fatalf("Error parsing note name %v", err)
 		}
-		gotOs, err := s.ListNoteOccurrences(pID, nID, "")
+		gotOs, _, err := s.ListNoteOccurrences(pID, nID, "", 100, "")
 		if err != nil {
 			t.Fatalf("ListNoteOccurrences got %v want success", err)
 		}

--- a/samples/server/go-server/api/server/storage/storager_test.go
+++ b/samples/server/go-server/api/server/storage/storager_test.go
@@ -648,4 +648,54 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			t.Fatalf("Got %s want %s", p.Name, name.FormatProject(pID3))
 		}
 	})
+
+	t.Run("OperationPagination", func(t *testing.T) {
+		s, cleanUp := createStore(t)
+		defer cleanUp()
+		pID := "project1"
+		oID1 := "operation1"
+		op1 := testutil.Operation(pID)
+		op1.Name = name.FormatOperation(pID, oID1)
+		if err := s.CreateOperation(op1); err != nil {
+			t.Errorf("CreateOperation got %v want success", err)
+		}
+		oID2 := "operation2"
+		op2 := testutil.Operation(pID)
+		op2.Name = name.FormatOperation(pID, oID2)
+		if err := s.CreateOperation(op2); err != nil {
+			t.Errorf("CreateOperation got %v want success", err)
+		}
+		oID3 := "operation3"
+		op3 := testutil.Operation(pID)
+		op3.Name = name.FormatOperation(pID, oID3)
+		if err := s.CreateOperation(op3); err != nil {
+			t.Errorf("CreateOperation got %v want success", err)
+		}
+		filter := "filters_are_yet_to_be_implemented"
+		// Get operations
+		gotOperations, lastPage, err := s.ListOperations(pID, filter, 2, "")
+		if err != nil {
+			t.Fatalf("ListOperations got %v want success", err)
+		}
+		if len(gotOperations) != 2 {
+			t.Errorf("ListOperations got %v operations, want 2", len(gotOperations))
+		}
+		if p := gotOperations[0]; p.Name != name.FormatOperation(pID, oID1) {
+			t.Fatalf("Got %s want %s", p.Name, name.FormatOperation(pID, oID1))
+		}
+		if p := gotOperations[1]; p.Name != name.FormatOperation(pID, oID2) {
+			t.Fatalf("Got %s want %s", p.Name, name.FormatOperation(pID, oID2))
+		}
+		// Get operations again
+		gotOperations, _, err = s.ListOperations(pID, filter, 100, lastPage)
+		if err != nil {
+			t.Fatalf("ListOperations got %v want success", err)
+		}
+		if len(gotOperations) != 1 {
+			t.Errorf("ListOperations got %v operations, want 1", len(gotOperations))
+		}
+		if p := gotOperations[0]; p.Name != name.FormatOperation(pID, oID3) {
+			t.Fatalf("Got %s want %s", p.Name, name.FormatOperation(pID, oID3))
+		}
+	})
 }

--- a/samples/server/go-server/api/server/storage/storager_test.go
+++ b/samples/server/go-server/api/server/storage/storager_test.go
@@ -438,7 +438,8 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			}
 			wantProjectNames = append(wantProjectNames, name.FormatProject(pID))
 		}
-		gotProjects, _, err := s.ListProjects(&server.ListOptions{PageSize: 100})
+		filter := "filters_are_yet_to_be_implemented"
+		gotProjects, _, err := s.ListProjects(filter, 100, "")
 		if err != nil {
 			t.Fatalf("ListProjects got %v want success", err)
 		}
@@ -620,9 +621,9 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 		if err := s.CreateProject(pID3); err != nil {
 			t.Errorf("CreateProject got %v want success", err)
 		}
-		options := &server.ListOptions{PageSize: 2}
+		filter := "filters_are_yet_to_be_implemented"
 		// Get projects
-		gotProjects, lastPage, err := s.ListProjects(options)
+		gotProjects, lastPage, err := s.ListProjects(filter, 2, "")
 		if err != nil {
 			t.Fatalf("ListProjects got %v want success", err)
 		}
@@ -636,8 +637,7 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			t.Fatalf("Got %s want %s", p.Name, name.FormatProject(pID2))
 		}
 		// Get projects again
-		options.PageToken = lastPage
-		gotProjects, _, err = s.ListProjects(options)
+		gotProjects, _, err = s.ListProjects(filter, 100, lastPage)
 		if err != nil {
 			t.Fatalf("ListProjects got %v want success", err)
 		}

--- a/samples/server/go-server/api/server/storage/storager_test.go
+++ b/samples/server/go-server/api/server/storage/storager_test.go
@@ -754,6 +754,62 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 		}
 	})
 
+	t.Run("NoteOccurrencePagination", func(t *testing.T) {
+		s, cleanUp := createStore(t)
+		defer cleanUp()
+		pID := "project"
+		nPID := "noteproject"
+		oID1 := "occurrence1"
+		n := testutil.Note(nPID)
+		if err := s.CreateNote(n); err != nil {
+			t.Fatalf("CreateNote got %v want success", err)
+		}
+		op1 := testutil.Occurrence(pID, n.Name)
+		op1.Name = name.FormatOccurrence(pID, oID1)
+		if err := s.CreateOccurrence(op1); err != nil {
+			t.Errorf("CreateOccurrence got %v want success", err)
+		}
+		oID2 := "occurrence2"
+		op2 := testutil.Occurrence(pID, n.Name)
+		op2.Name = name.FormatOccurrence(pID, oID2)
+		if err := s.CreateOccurrence(op2); err != nil {
+			t.Errorf("CreateOccurrence got %v want success", err)
+		}
+		oID3 := "occurrence3"
+		op3 := testutil.Occurrence(pID, n.Name)
+		op3.Name = name.FormatOccurrence(pID, oID3)
+		if err := s.CreateOccurrence(op3); err != nil {
+			t.Errorf("CreateOccurrence got %v want success", err)
+		}
+		filter := "filters_are_yet_to_be_implemented"
+		_, nID, err := name.ParseNote(n.Name)
+		// Get occurrences
+		gotOccurrences, lastPage, err := s.ListNoteOccurrences(nPID, nID, filter, 2, "")
+		if err != nil {
+			t.Fatalf("ListNoteOccurrences got %v want success", err)
+		}
+		if len(gotOccurrences) != 2 {
+			t.Errorf("ListNoteOccurrences got %v occurrences, want 2", len(gotOccurrences))
+		}
+		if p := gotOccurrences[0]; p.Name != name.FormatOccurrence(pID, oID1) {
+			t.Fatalf("Got %s want %s", p.Name, name.FormatOccurrence(pID, oID1))
+		}
+		if p := gotOccurrences[1]; p.Name != name.FormatOccurrence(pID, oID2) {
+			t.Fatalf("Got %s want %s", p.Name, name.FormatOccurrence(pID, oID2))
+		}
+		// Get occurrences again
+		gotOccurrences, _, err = s.ListNoteOccurrences(nPID, nID, filter, 100, lastPage)
+		if err != nil {
+			t.Fatalf("ListNoteOccurrences got %v want success", err)
+		}
+		if len(gotOccurrences) != 1 {
+			t.Errorf("ListNoteOccurrences got %v operations, want 1", len(gotOccurrences))
+		}
+		if p := gotOccurrences[0]; p.Name != name.FormatOccurrence(pID, oID3) {
+			t.Fatalf("Got %s want %s", p.Name, name.FormatOccurrence(pID, oID3))
+		}
+	})
+
 	t.Run("OperationPagination", func(t *testing.T) {
 		s, cleanUp := createStore(t)
 		defer cleanUp()

--- a/samples/server/go-server/api/server/storage/storager_test.go
+++ b/samples/server/go-server/api/server/storage/storager_test.go
@@ -649,6 +649,56 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 		}
 	})
 
+	t.Run("NotesPagination", func(t *testing.T) {
+		s, cleanUp := createStore(t)
+		defer cleanUp()
+		pID := "project"
+		nID1 := "note1"
+		op1 := testutil.Note(pID)
+		op1.Name = name.FormatNote(pID, nID1)
+		if err := s.CreateNote(op1); err != nil {
+			t.Errorf("CreateNote got %v want success", err)
+		}
+		nID2 := "note2"
+		op2 := testutil.Note(pID)
+		op2.Name = name.FormatNote(pID, nID2)
+		if err := s.CreateNote(op2); err != nil {
+			t.Errorf("CreateNote got %v want success", err)
+		}
+		nID3 := "note3"
+		op3 := testutil.Note(pID)
+		op3.Name = name.FormatNote(pID, nID3)
+		if err := s.CreateNote(op3); err != nil {
+			t.Errorf("CreateNote got %v want success", err)
+		}
+		filter := "filters_are_yet_to_be_implemented"
+		// Get occurrences
+		gotNotes, lastPage, err := s.ListNotes(pID, filter, 2, "")
+		if err != nil {
+			t.Fatalf("ListNotes got %v want success", err)
+		}
+		if len(gotNotes) != 2 {
+			t.Errorf("ListNotes got %v notes, want 2", len(gotNotes))
+		}
+		if p := gotNotes[0]; p.Name != name.FormatNote(pID, nID1) {
+			t.Fatalf("Got %s want %s", p.Name, name.FormatNote(pID, nID1))
+		}
+		if p := gotNotes[1]; p.Name != name.FormatNote(pID, nID2) {
+			t.Fatalf("Got %s want %s", p.Name, name.FormatNote(pID, nID2))
+		}
+		// Get occurrences again
+		gotNotes, _, err = s.ListNotes(pID, filter, 100, lastPage)
+		if err != nil {
+			t.Fatalf("ListNotes got %v want success", err)
+		}
+		if len(gotNotes) != 1 {
+			t.Errorf("ListNotes got %v notes, want 1", len(gotNotes))
+		}
+		if p := gotNotes[0]; p.Name != name.FormatNote(pID, nID3) {
+			t.Fatalf("Got %s want %s", p.Name, name.FormatNote(pID, nID3))
+		}
+	})
+
 	t.Run("OccurrencePagination", func(t *testing.T) {
 		s, cleanUp := createStore(t)
 		defer cleanUp()

--- a/samples/server/go-server/api/server/storage/storager_test.go
+++ b/samples/server/go-server/api/server/storage/storager_test.go
@@ -476,7 +476,7 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			}
 			ops = append(ops, *o)
 		}
-		gotOs, err := s.ListOperations(findProject, "")
+		gotOs, _, err := s.ListOperations(findProject, "", 100, "")
 		if err != nil {
 			t.Fatalf("ListOperations got %v want success", err)
 		}

--- a/samples/server/go-server/api/server/v1alpha1/impl.go
+++ b/samples/server/go-server/api/server/v1alpha1/impl.go
@@ -323,11 +323,14 @@ func (g *Grafeas) UpdateOperation(ctx context.Context, req *pb.UpdateOperationRe
 // ListProjects returns the project id for all projects in the backing datastore.
 func (g *Grafeas) ListProjects(ctx context.Context, req *pb.ListProjectsRequest) (*pb.ListProjectsResponse, error) {
 	// TODO: support filters
-	ps, err := g.S.ListProjects(req.Filter)
+	ps, nextToken, err := g.S.ListProjects(newListOptions(req))
 	if err != nil {
 		return nil, status.Error(codes.Unknown, "Failed to list projects")
 	}
-	return &pb.ListProjectsResponse{Projects: ps}, nil
+	return &pb.ListProjectsResponse{
+		Projects:      ps,
+		NextPageToken: nextToken,
+	}, nil
 }
 
 func (g *Grafeas) ListOperations(ctx context.Context, req *opspb.ListOperationsRequest) (*opspb.ListOperationsResponse, error) {
@@ -388,4 +391,15 @@ func (g *Grafeas) ListNoteOccurrences(ctx context.Context, req *pb.ListNoteOccur
 
 func (g *Grafeas) CancelOperation(context.Context, *opspb.CancelOperationRequest) (*empty.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "Currently Unimplemented")
+}
+
+func newListOptions(req *pb.ListProjectsRequest) *server.ListOptions {
+	if req.PageSize == 0 {
+		req.PageSize = 100
+	}
+	return &server.ListOptions{
+		Filter:    req.Filter,
+		PageSize:  req.PageSize,
+		PageToken: req.PageToken,
+	}
 }

--- a/samples/server/go-server/api/server/v1alpha1/impl.go
+++ b/samples/server/go-server/api/server/v1alpha1/impl.go
@@ -383,6 +383,9 @@ func (g *Grafeas) ListOccurrences(ctx context.Context, req *pb.ListOccurrencesRe
 		return nil, err
 	}
 	// TODO: support filters - prioritizing resource url
+	if req.PageSize == 0 {
+		req.PageSize = 100
+	}
 	os, nextToken, err := g.S.ListOccurrences(pID, req.Filter, int(req.PageSize), req.PageToken)
 	if err != nil {
 		return nil, status.Error(codes.Unknown, "Failed to list occurrences")
@@ -400,6 +403,9 @@ func (g *Grafeas) ListNoteOccurrences(ctx context.Context, req *pb.ListNoteOccur
 		return nil, status.Error(codes.InvalidArgument, "Invalid note name")
 	}
 	// TODO: support filters - prioritizing resource url
+	if req.PageSize == 0 {
+		req.PageSize = 100
+	}
 	os, nextToken, gErr := g.S.ListNoteOccurrences(pID, nID, req.Filter, int(req.PageSize), req.PageToken)
 	if gErr != nil {
 		return nil, gErr

--- a/samples/server/go-server/api/server/v1alpha1/impl.go
+++ b/samples/server/go-server/api/server/v1alpha1/impl.go
@@ -343,11 +343,17 @@ func (g *Grafeas) ListOperations(ctx context.Context, req *opspb.ListOperationsR
 		return nil, status.Error(codes.InvalidArgument, "Invalid Project name")
 	}
 	// TODO: support filters
-	ops, err := g.S.ListOperations(pID, req.Filter)
+	if req.PageSize == 0 {
+		req.PageSize = 100
+	}
+	ops, nextToken, err := g.S.ListOperations(pID, req.Filter, int(req.PageSize), req.PageToken)
 	if err != nil {
 		return nil, status.Error(codes.Unknown, "Failed to list operations")
 	}
-	return &opspb.ListOperationsResponse{Operations: ops}, nil
+	return &opspb.ListOperationsResponse{
+		Operations:    ops,
+		NextPageToken: nextToken,
+	}, nil
 }
 
 func (g *Grafeas) ListNotes(ctx context.Context, req *pb.ListNotesRequest) (*pb.ListNotesResponse, error) {

--- a/samples/server/go-server/api/server/v1alpha1/impl.go
+++ b/samples/server/go-server/api/server/v1alpha1/impl.go
@@ -363,6 +363,9 @@ func (g *Grafeas) ListNotes(ctx context.Context, req *pb.ListNotesRequest) (*pb.
 		return nil, status.Error(codes.InvalidArgument, "Invalid Project name")
 	}
 	// TODO: support filters
+	if req.PageSize == 0 {
+		req.PageSize = 100
+	}
 	ns, nextToken, err := g.S.ListNotes(pID, req.Filter, int(req.PageSize), req.PageToken)
 	if err != nil {
 		return nil, status.Error(codes.Unknown, "Failed to list notes")

--- a/samples/server/go-server/api/server/v1alpha1/impl.go
+++ b/samples/server/go-server/api/server/v1alpha1/impl.go
@@ -363,11 +363,14 @@ func (g *Grafeas) ListNotes(ctx context.Context, req *pb.ListNotesRequest) (*pb.
 		return nil, status.Error(codes.InvalidArgument, "Invalid Project name")
 	}
 	// TODO: support filters
-	ns, err := g.S.ListNotes(pID, req.Filter)
+	ns, nextToken, err := g.S.ListNotes(pID, req.Filter, int(req.PageSize), req.PageToken)
 	if err != nil {
 		return nil, status.Error(codes.Unknown, "Failed to list notes")
 	}
-	return &pb.ListNotesResponse{Notes: ns}, nil
+	return &pb.ListNotesResponse{
+		Notes:         ns,
+		NextPageToken: nextToken,
+	}, nil
 }
 
 func (g *Grafeas) ListOccurrences(ctx context.Context, req *pb.ListOccurrencesRequest) (*pb.ListOccurrencesResponse, error) {
@@ -377,11 +380,14 @@ func (g *Grafeas) ListOccurrences(ctx context.Context, req *pb.ListOccurrencesRe
 		return nil, err
 	}
 	// TODO: support filters - prioritizing resource url
-	os, err := g.S.ListOccurrences(pID, req.Filter)
+	os, nextToken, err := g.S.ListOccurrences(pID, req.Filter, int(req.PageSize), req.PageToken)
 	if err != nil {
 		return nil, status.Error(codes.Unknown, "Failed to list occurrences")
 	}
-	return &pb.ListOccurrencesResponse{Occurrences: os}, nil
+	return &pb.ListOccurrencesResponse{
+		Occurrences:   os,
+		NextPageToken: nextToken,
+	}, nil
 }
 
 func (g *Grafeas) ListNoteOccurrences(ctx context.Context, req *pb.ListNoteOccurrencesRequest) (*pb.ListNoteOccurrencesResponse, error) {
@@ -391,11 +397,14 @@ func (g *Grafeas) ListNoteOccurrences(ctx context.Context, req *pb.ListNoteOccur
 		return nil, status.Error(codes.InvalidArgument, "Invalid note name")
 	}
 	// TODO: support filters - prioritizing resource url
-	os, gErr := g.S.ListNoteOccurrences(pID, nID, req.Filter)
+	os, nextToken, gErr := g.S.ListNoteOccurrences(pID, nID, req.Filter, int(req.PageSize), req.PageToken)
 	if gErr != nil {
 		return nil, gErr
 	}
-	return &pb.ListNoteOccurrencesResponse{Occurrences: os}, nil
+	return &pb.ListNoteOccurrencesResponse{
+		Occurrences:   os,
+		NextPageToken: nextToken,
+	}, nil
 }
 
 func (g *Grafeas) CancelOperation(context.Context, *opspb.CancelOperationRequest) (*empty.Empty, error) {

--- a/samples/server/go-server/api/server/v1alpha1/impl.go
+++ b/samples/server/go-server/api/server/v1alpha1/impl.go
@@ -323,7 +323,10 @@ func (g *Grafeas) UpdateOperation(ctx context.Context, req *pb.UpdateOperationRe
 // ListProjects returns the project id for all projects in the backing datastore.
 func (g *Grafeas) ListProjects(ctx context.Context, req *pb.ListProjectsRequest) (*pb.ListProjectsResponse, error) {
 	// TODO: support filters
-	ps, nextToken, err := g.S.ListProjects(newListOptions(req))
+	if req.PageSize == 0 {
+		req.PageSize = 100
+	}
+	ps, nextToken, err := g.S.ListProjects(req.Filter, int(req.PageSize), req.PageToken)
 	if err != nil {
 		return nil, status.Error(codes.Unknown, "Failed to list projects")
 	}
@@ -391,15 +394,4 @@ func (g *Grafeas) ListNoteOccurrences(ctx context.Context, req *pb.ListNoteOccur
 
 func (g *Grafeas) CancelOperation(context.Context, *opspb.CancelOperationRequest) (*empty.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "Currently Unimplemented")
-}
-
-func newListOptions(req *pb.ListProjectsRequest) *server.ListOptions {
-	if req.PageSize == 0 {
-		req.PageSize = 100
-	}
-	return &server.ListOptions{
-		Filter:    req.Filter,
-		PageSize:  req.PageSize,
-		PageToken: req.PageToken,
-	}
 }

--- a/server-go/storage.go
+++ b/server-go/storage.go
@@ -73,8 +73,9 @@ type Storager interface {
 	// ListOccurrences returns the occurrences for this project ID (pID)
 	ListOccurrences(pID, filters string) ([]*pb.Occurrence, error)
 
-	// ListOperations returns the operations for this project (pID)
-	ListOperations(pID, filters string) ([]*opspb.Operation, error)
+	// ListOperations returns up to pageSize number of operations for this project (pID) beginning
+	// at pageToken (or from start if pageToken is the emtpy string).
+	ListOperations(pID, filters string, pageSize int, pageToken string) ([]*opspb.Operation, string, error)
 
 	// UpdateNote updates the existing note with the given pID and nID
 	UpdateNote(pID, nID string, n *pb.Note) error

--- a/server-go/storage.go
+++ b/server-go/storage.go
@@ -19,6 +19,16 @@ import (
 	opspb "google.golang.org/genproto/googleapis/longrunning"
 )
 
+type ListOptions struct {
+	// Filter string
+	Filter string
+	// Maximum number of items to list
+	PageSize int32
+	// Token representing the first item to be listed.
+	// Use an empty token to list from beginning of the list.
+	PageToken string
+}
+
 // Storager is the interface that a Grafeas storage implementation would provide
 type Storager interface {
 	// CreateProject adds the specified project
@@ -60,8 +70,8 @@ type Storager interface {
 	// GetOperation returns the operation with pID and oID
 	GetOperation(pID, opID string) (*opspb.Operation, error)
 
-	// ListProjects returns the project id for all projects
-	ListProjects(filters string) ([]*pb.Project, error)
+	// ListProjects returns the project id for all projects and a next page token
+	ListProjects(options *ListOptions) ([]*pb.Project, string, error)
 
 	// ListNoteOccurrences returns the occcurrences on the particular note (nID) for this project (pID)
 	ListNoteOccurrences(pID, nID, filters string) ([]*pb.Occurrence, error)

--- a/server-go/storage.go
+++ b/server-go/storage.go
@@ -19,16 +19,6 @@ import (
 	opspb "google.golang.org/genproto/googleapis/longrunning"
 )
 
-type ListOptions struct {
-	// Filter string
-	Filter string
-	// Maximum number of items to list
-	PageSize int32
-	// Token representing the first item to be listed.
-	// Use an empty token to list from beginning of the list.
-	PageToken string
-}
-
 // Storager is the interface that a Grafeas storage implementation would provide
 type Storager interface {
 	// CreateProject adds the specified project
@@ -70,8 +60,9 @@ type Storager interface {
 	// GetOperation returns the operation with pID and oID
 	GetOperation(pID, opID string) (*opspb.Operation, error)
 
-	// ListProjects returns the project id for all projects and a next page token
-	ListProjects(options *ListOptions) ([]*pb.Project, string, error)
+	// ListProjects returns up to pageSize number of projects beginning at pageToken (or from
+	// start if pageToken is the emtpy string).
+	ListProjects(filter string, pageSize int, pageToken string) ([]*pb.Project, string, error)
 
 	// ListNoteOccurrences returns the occcurrences on the particular note (nID) for this project (pID)
 	ListNoteOccurrences(pID, nID, filters string) ([]*pb.Occurrence, error)

--- a/server-go/storage.go
+++ b/server-go/storage.go
@@ -64,14 +64,17 @@ type Storager interface {
 	// start if pageToken is the emtpy string).
 	ListProjects(filter string, pageSize int, pageToken string) ([]*pb.Project, string, error)
 
-	// ListNoteOccurrences returns the occcurrences on the particular note (nID) for this project (pID)
-	ListNoteOccurrences(pID, nID, filters string) ([]*pb.Occurrence, error)
+	// ListNoteOccurrences returns up to pageSize number of occcurrences on the particular note (nID)
+	// for this project (pID) projects beginning at pageToken (or from start if pageToken is the emtpy string).
+	ListNoteOccurrences(pID, nID, filters string, pageSize int, pageToken string) ([]*pb.Occurrence, string, error)
 
-	// ListNotes returns the notes for for this project (pID)
-	ListNotes(pID, filters string) ([]*pb.Note, error)
+	// ListNotes returns up to pageSize number of notes for this project (pID) beginning
+	// at pageToken (or from start if pageToken is the emtpy string).
+	ListNotes(pID, filters string, pageSize int, pageToken string) ([]*pb.Note, string, error)
 
-	// ListOccurrences returns the occurrences for this project ID (pID)
-	ListOccurrences(pID, filters string) ([]*pb.Occurrence, error)
+	// ListOccurrences returns up to pageSize number of occurrences for this project (pID) beginning
+	// at pageToken (or from start if pageToken is the emtpy string).
+	ListOccurrences(pID, filters string, pageSize int, pageToken string) ([]*pb.Occurrence, string, error)
 
 	// ListOperations returns up to pageSize number of operations for this project (pID) beginning
 	// at pageToken (or from start if pageToken is the emtpy string).

--- a/vendor/github.com/fernet/fernet-go/License
+++ b/vendor/github.com/fernet/fernet-go/License
@@ -1,0 +1,20 @@
+Copyright © 2013 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/fernet/fernet-go/Readme
+++ b/vendor/github.com/fernet/fernet-go/Readme
@@ -1,0 +1,22 @@
+Fernet takes a user-provided *message* (an arbitrary sequence of
+bytes), a *key* (256 bits), and the current time, and produces a
+*token*, which contains the message in a form that can't be read
+or altered without the key.
+
+This package is compatible with the other implementations at
+https://github.com/fernet. They can exchange tokens freely among
+each other.
+
+Documentation: http://godoc.org/github.com/fernet/fernet-go
+
+
+INSTALL
+
+	$ go get github.com/fernet/fernet-go
+
+
+For more information and background, see the Fernet spec at
+https://github.com/fernet/spec.
+
+Fernet is distributed under the terms of the MIT license.
+See the License file for details.

--- a/vendor/github.com/fernet/fernet-go/fernet.go
+++ b/vendor/github.com/fernet/fernet-go/fernet.go
@@ -1,0 +1,168 @@
+// Package fernet takes a user-provided message (an arbitrary
+// sequence of bytes), a key (256 bits), and the current time,
+// and produces a token, which contains the message in a form
+// that can't be read or altered without the key.
+//
+// For more information and background, see the Fernet spec
+// at https://github.com/fernet/spec.
+//
+// Subdirectories in this package provide command-line tools
+// for working with Fernet keys and tokens.
+package fernet
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/binary"
+	"io"
+	"time"
+)
+
+const (
+	version      byte = 0x80
+	tsOffset          = 1
+	ivOffset          = tsOffset + 8
+	payOffset         = ivOffset + aes.BlockSize
+	overhead          = 1 + 8 + aes.BlockSize + sha256.Size // ver + ts + iv + hmac
+	maxClockSkew      = 60 * time.Second
+)
+
+var encoding = base64.URLEncoding
+
+// generates a token from msg, writes it into tok, and returns the
+// number of bytes generated, which is encodedLen(msg).
+// len(tok) must be >= encodedLen(len(msg))
+func gen(tok, msg, iv []byte, ts time.Time, k *Key) int {
+	tok[0] = version
+	binary.BigEndian.PutUint64(tok[tsOffset:], uint64(ts.Unix()))
+	copy(tok[ivOffset:], iv)
+	p := tok[payOffset:]
+	n := pad(p, msg, aes.BlockSize)
+	bc, _ := aes.NewCipher(k.cryptBytes())
+	cipher.NewCBCEncrypter(bc, iv).CryptBlocks(p[:n], p[:n])
+	genhmac(p[n:n], tok[:payOffset+n], k.signBytes())
+	return payOffset + n + sha256.Size
+}
+
+// token length for input msg of length n, not including base64
+func encodedLen(n int) int {
+	const k = aes.BlockSize
+	return n/k*k + k + overhead
+}
+
+// max msg length for tok of length n, for binary token (no base64)
+// upper bound; not exact
+func decodedLen(n int) int {
+	return n - overhead
+}
+
+// if msg is nil, decrypts in place and returns a slice of tok.
+func verify(msg, tok []byte, ttl time.Duration, now time.Time, k *Key) []byte {
+	if len(tok) < 1 || tok[0] != version {
+		return nil
+	}
+	ts := time.Unix(int64(binary.BigEndian.Uint64(tok[1:])), 0)
+	if ttl >= 0 && (now.After(ts.Add(ttl)) || ts.After(now.Add(maxClockSkew))) {
+		return nil
+	}
+	n := len(tok) - sha256.Size
+	var hmac [sha256.Size]byte
+	genhmac(hmac[:0], tok[:n], k.signBytes())
+	if subtle.ConstantTimeCompare(tok[n:], hmac[:]) != 1 {
+		return nil
+	}
+	pay := tok[payOffset : len(tok)-sha256.Size]
+	if len(pay)%aes.BlockSize != 0 {
+		return nil
+	}
+	if msg != nil {
+		copy(msg, pay)
+		pay = msg
+	}
+	bc, _ := aes.NewCipher(k.cryptBytes())
+	iv := tok[9:][:aes.BlockSize]
+	cipher.NewCBCDecrypter(bc, iv).CryptBlocks(pay, pay)
+	return unpad(pay)
+}
+
+// Pads p to a multiple of k using PKCS #7 standard block padding.
+// See http://tools.ietf.org/html/rfc5652#section-6.3.
+func pad(q, p []byte, k int) int {
+	n := len(p)/k*k + k
+	copy(q, p)
+	c := byte(n - len(p))
+	for i := len(p); i < n; i++ {
+		q[i] = c
+	}
+	return n
+}
+
+// Removes PKCS #7 standard block padding from p.
+// See http://tools.ietf.org/html/rfc5652#section-6.3.
+// This function is the inverse of pad.
+// If the padding is not well-formed, unpad returns nil.
+func unpad(p []byte) []byte {
+	c := p[len(p)-1]
+	for i := len(p) - int(c); i < len(p); i++ {
+		if i < 0 || p[i] != c {
+			return nil
+		}
+	}
+	return p[:len(p)-int(c)]
+}
+
+func b64enc(src []byte) []byte {
+	dst := make([]byte, encoding.EncodedLen(len(src)))
+	encoding.Encode(dst, src)
+	return dst
+}
+
+func b64dec(src []byte) []byte {
+	dst := make([]byte, encoding.DecodedLen(len(src)))
+	n, err := encoding.Decode(dst, src)
+	if err != nil {
+		return nil
+	}
+	return dst[:n]
+}
+
+func genhmac(q, p, k []byte) {
+	h := hmac.New(sha256.New, k)
+	h.Write(p)
+	h.Sum(q)
+}
+
+// EncryptAndSign encrypts and signs msg with key k and returns the resulting
+// fernet token. If msg contains text, the text should be encoded
+// with UTF-8 to follow fernet convention.
+func EncryptAndSign(msg []byte, k *Key) (tok []byte, err error) {
+	iv := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, err
+	}
+	b := make([]byte, encodedLen(len(msg)))
+	n := gen(b, msg, iv, time.Now(), k)
+	tok = make([]byte, encoding.EncodedLen(n))
+	encoding.Encode(tok, b[:n])
+	return tok, nil
+}
+
+// VerifyAndDecrypt verifies that tok is a valid fernet token that was signed
+// with a key in k at most ttl time ago only if ttl is greater than zero.
+// Returns the message contained in tok if tok is valid, otherwise nil.
+func VerifyAndDecrypt(tok []byte, ttl time.Duration, k []*Key) (msg []byte) {
+	b := make([]byte, encoding.DecodedLen(len(tok)))
+	n, _ := encoding.Decode(b, tok)
+	for _, k1 := range k {
+		msg = verify(nil, b[:n], ttl, time.Now(), k1)
+		if msg != nil {
+			return msg
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/fernet/fernet-go/generate.json
+++ b/vendor/github.com/fernet/fernet-go/generate.json
@@ -1,0 +1,9 @@
+[
+  {
+    "token": "gAAAAAAdwJ6wAAECAwQFBgcICQoLDA0ODy021cpGVWKZ_eEwCGM4BLLF_5CV9dOPmrhuVUPgJobwOz7JcbmrR64jVmpU4IwqDA==",
+    "now": "1985-10-26T01:20:00-07:00",
+    "iv": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    "src": "hello",
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  }
+]

--- a/vendor/github.com/fernet/fernet-go/invalid.json
+++ b/vendor/github.com/fernet/fernet-go/invalid.json
@@ -1,0 +1,58 @@
+[
+  {
+    "desc": "incorrect mac",
+    "token": "gAAAAAAdwJ6xAAECAwQFBgcICQoLDA0OD3HkMATM5lFqGaerZ-fWPAl1-szkFVzXTuGb4hR8AKtwcaX1YdykQUFBQUFBQUFBQQ==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "too short",
+    "token": "gAAAAAAdwJ6xAAECAwQFBgcICQoLDA0OD3HkMATM5lFqGaerZ-fWPA==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "invalid base64",
+    "token": "%%%%%%%%%%%%%AECAwQFBgcICQoLDA0OD3HkMATM5lFqGaerZ-fWPAl1-szkFVzXTuGb4hR8AKtwcaX1YdykRtfsH-p1YsUD2Q==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "payload size not multiple of block size",
+    "token": "gAAAAAAdwJ6xAAECAwQFBgcICQoLDA0OD3HkMATM5lFqGaerZ-fWPOm73QeoCk9uGib28Xe5vz6oxq5nmxbx_v7mrfyudzUm",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "payload padding error",
+    "token": "gAAAAAAdwJ6xAAECAwQFBgcICQoLDA0ODz4LEpdELGQAad7aNEHbf-JkLPIpuiYRLQ3RtXatOYREu2FWke6CnJNYIbkuKNqOhw==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "far-future TS (unacceptable clock skew)",
+    "token": "gAAAAAAdwStRAAECAwQFBgcICQoLDA0OD3HkMATM5lFqGaerZ-fWPAnja1xKYyhd-Y6mSkTOyTGJmw2Xc2a6kBd-iX9b_qXQcw==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "expired TTL",
+    "token": "gAAAAAAdwJ6xAAECAwQFBgcICQoLDA0OD3HkMATM5lFqGaerZ-fWPAl1-szkFVzXTuGb4hR8AKtwcaX1YdykRtfsH-p1YsUD2Q==",
+    "now": "1985-10-26T01:21:31-07:00",
+    "ttl_sec": 60,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "incorrect IV (causes padding error)",
+    "token": "gAAAAAAdwJ6xBQECAwQFBgcICQoLDA0OD3HkMATM5lFqGaerZ-fWPAkLhFLHpGtDBRLRTZeUfWgHSv49TF2AUEZ1TIvcZjK1zQ==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  }
+]

--- a/vendor/github.com/fernet/fernet-go/key.go
+++ b/vendor/github.com/fernet/fernet-go/key.go
@@ -1,0 +1,91 @@
+package fernet
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"io"
+)
+
+var (
+	errKeyLen = errors.New("fernet: key decodes to wrong size")
+	errNoKeys = errors.New("fernet: no keys provided")
+)
+
+// Key represents a key.
+type Key [32]byte
+
+func (k *Key) cryptBytes() []byte {
+	return k[len(k)/2:]
+}
+
+func (k *Key) signBytes() []byte {
+	return k[:len(k)/2]
+}
+
+// Generate initializes k with pseudorandom data from package crypto/rand.
+func (k *Key) Generate() error {
+	_, err := io.ReadFull(rand.Reader, k[:])
+	return err
+}
+
+// Encode returns the URL-safe base64 encoding of k.
+func (k *Key) Encode() string {
+	return encoding.EncodeToString(k[:])
+}
+
+// DecodeKey decodes a key from s and returns it. The key can be in
+// hexadecimal, standard base64, or URL-safe base64.
+func DecodeKey(s string) (*Key, error) {
+	var b []byte
+	var err error
+	if s == "" {
+		return nil, errors.New("empty key")
+	}
+	if len(s) == hex.EncodedLen(len(Key{})) {
+		b, err = hex.DecodeString(s)
+	} else {
+		b, err = base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			b, err = base64.URLEncoding.DecodeString(s)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(b) != len(Key{}) {
+		return nil, errKeyLen
+	}
+	k := new(Key)
+	copy(k[:], b)
+	return k, nil
+}
+
+// DecodeKeys decodes each element of a using DecodeKey and returns the
+// resulting keys. Requires at least one key.
+func DecodeKeys(a ...string) ([]*Key, error) {
+	if len(a) == 0 {
+		return nil, errNoKeys
+	}
+	var err error
+	ks := make([]*Key, len(a))
+	for i, s := range a {
+		ks[i], err = DecodeKey(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ks, nil
+}
+
+// MustDecodeKeys is like DecodeKeys, but panics if an error occurs.
+// It simplifies safe initialization of global variables holding
+// keys.
+func MustDecodeKeys(a ...string) []*Key {
+	k, err := DecodeKeys(a...)
+	if err != nil {
+		panic(err)
+	}
+	return k
+}

--- a/vendor/github.com/fernet/fernet-go/verify.json
+++ b/vendor/github.com/fernet/fernet-go/verify.json
@@ -1,0 +1,16 @@
+[
+  {
+    "token": "gAAAAAAdwJ6wAAECAwQFBgcICQoLDA0ODy021cpGVWKZ_eEwCGM4BLLF_5CV9dOPmrhuVUPgJobwOz7JcbmrR64jVmpU4IwqDA==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "src": "hello",
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "token": "gAAAAAAdwJ6wAAECAwQFBgcICQoLDA0ODy021cpGVWKZ_eEwCGM4BLLF_5CV9dOPmrhuVUPgJobwOz7JcbmrR64jVmpU4IwqDA==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": -1,
+    "src": "hello",
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  }
+]

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,6 +9,12 @@
 			"revisionTime": "2017-01-10T19:26:07Z"
 		},
 		{
+			"checksumSHA1": "AC3L+6uB5lMz2ysLswyI52jXWL8=",
+			"path": "github.com/fernet/fernet-go",
+			"revision": "1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2",
+			"revisionTime": "2015-07-09T19:54:58Z"
+		},
+		{
 			"checksumSHA1": "HmbftipkadrLlCfzzVQ+iFHbl6g=",
 			"path": "github.com/golang/glog",
 			"revision": "23def4e6c14b4da8ac2ed8007337bc5eb5007998",


### PR DESCRIPTION
This PR is a partial solution for #100. Only project pagination has been implemented. The reason for submitting a partial solution is to enable discussions before implementing pagination for all resource types.

Notes:
- I see a number of options for obfuscating page tokens:
  1. Don't
  2. Encode with e.g. base64
  3. Encrypt the tokens using a key that is only known to the server
  
  The memstore backend uses option 1in this PR (for simplicity).
  The postgres backend uses option 2 in this PR.
  Clair uses option 3.
  I started out with option 3 but figured I would keep it simple until I got some feedback. What is the preferred option   for the postgres backend? Is there any best practice at google? 

- I added a ListOptions struct to keep the number of parameters down. Not sure if this was an improvement or not. Feedback welcome.

- We might have to add new db indexes if the upcomming filtering functionality will support ordering.


