### PR TITLE
Modified code to ignore postgres settings when storage type is memstore

### DIFF
--- a/samples/server/go-server/api/server/config/config.go
+++ b/samples/server/go-server/api/server/config/config.go
@@ -67,6 +67,11 @@ func LoadConfig(fileName string) (*config, error) {
 		return nil, err
 	}
 	config := configFile.Grafeas
+
+	if config.StorageType == "memstore" {
+		return config, nil
+	}
+
 	// Generate a pagination key if none is provided.
 	if config.PgSQLConfig.PaginationKey == "" {
 		log.Println("pagination key is empty, generating...")

--- a/samples/server/go-server/api/server/config/config.go
+++ b/samples/server/go-server/api/server/config/config.go
@@ -68,23 +68,21 @@ func LoadConfig(fileName string) (*config, error) {
 	}
 	config := configFile.Grafeas
 
-	if config.StorageType == "memstore" {
-		return config, nil
-	}
-
-	// Generate a pagination key if none is provided.
-	if config.PgSQLConfig.PaginationKey == "" {
-		log.Println("pagination key is empty, generating...")
-		var key fernet.Key
-		if err = key.Generate(); err != nil {
-			return nil, err
-		}
-		config.PgSQLConfig.PaginationKey = key.Encode()
-	} else {
-		_, err = fernet.DecodeKey(config.PgSQLConfig.PaginationKey)
-		if err != nil {
-			err = errors.New("Invalid Pagination key; must be 32-bit URL-safe base64")
-			return nil, err
+	if config.StorageType == "postgres" {
+		// Generate a pagination key if none is provided.
+		if config.PgSQLConfig.PaginationKey == "" {
+			log.Println("pagination key is empty, generating...")
+			var key fernet.Key
+			if err = key.Generate(); err != nil {
+				return nil, err
+			}
+			config.PgSQLConfig.PaginationKey = key.Encode()
+		} else {
+			_, err = fernet.DecodeKey(config.PgSQLConfig.PaginationKey)
+			if err != nil {
+				err = errors.New("Invalid Pagination key; must be 32-bit URL-safe base64")
+				return nil, err
+			}
 		}
 	}
 	return config, nil


### PR DESCRIPTION
Modified code to ignore postgres settings when storage type is memstore, this allows removing postgres setting from config file when not used or will generate runtime error "invalid memory address or nil pointer dereference"