### PR TITLE
Remove UNSUPPORTED_RESOURCE option for AnalysisStatus

### DIFF
--- a/v1beta1/proto/discovery.proto
+++ b/v1beta1/proto/discovery.proto
@@ -70,8 +70,6 @@ message Discovered {
     // Analysis has finished unsuccessfully, the analysis itself is in a bad
     // state.
     FINISHED_FAILED = 4;
-    // Analysis will not happen, the resource is not supported.
-    UNSUPPORTED_RESOURCE = 5;
   }
 
   // The status of discovery for the resource.


### PR DESCRIPTION
The details of an error are stored in `analysis_status_error`.