### PR TITLE
[Dockerfile] bump golang and remove trailing whitespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN CGO_ENABLED=0 go build -o grafeas-server .
 
 FROM alpine:latest
 WORKDIR /
-COPY --from=0 /go/src/github.com/grafeas/grafeas/samples/server/go-server/api/server/main/grafeas-server /grafeas-server 
+COPY --from=0 /go/src/github.com/grafeas/grafeas/samples/server/go-server/api/server/main/grafeas-server /grafeas-server
 EXPOSE 8080
 CMD ["/grafeas-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1.10.3
 COPY . /go/src/github.com/grafeas/grafeas/
 WORKDIR /go/src/github.com/grafeas/grafeas/samples/server/go-server/api/server/main
 RUN CGO_ENABLED=0 go build -o grafeas-server .


### PR DESCRIPTION
:wave: hi friends

- bumping go
- removing trailing whitespace

```sh
~/src/github.com/jonpulsifer/grafeas (bump-go) $ docker run -d --rm -p 8080:8080 grafeas
~/src/github.com/jonpulsifer/grafeas (bump-go) $ curl localhost:8080/v1alpha1/projects
{"projects":[],"nextPageToken":"0"}
```