### PR TITLE
[sample server] expose Grafeas on 0.0.0.0

### DIFF
--- a/samples/server/go-server/api/server/config/config.go
+++ b/samples/server/go-server/api/server/config/config.go
@@ -41,7 +41,7 @@ type config struct {
 func defaultConfig() *config {
 	return &config{
 		API: &api.Config{
-			Address:  "localhost:8080",
+			Address:  "0.0.0.0:8080",
 			CertFile: "",
 			KeyFile:  "",
 			CAFile:   "",


### PR DESCRIPTION
Fixes https://github.com/grafeas/grafeas/issues/166 by changing the
defaultConfig to serve on `0.0.0.0` instead of `localhost`

Signed-off-by: Jonathan Pulsifer <jonathan@pulsifer.ca>