### PR TITLE
Allow users not named postgres

### DIFF
--- a/samples/server/go-server/api/server/storage/pgsqlconfig.go
+++ b/samples/server/go-server/api/server/storage/pgsqlconfig.go
@@ -27,10 +27,6 @@ type PgSQLConfig struct {
 	PaginationKey string `yaml:"paginationkey"`
 }
 
-func createSourceString(config *PgSQLConfig) string {
-	return fmt.Sprintf("postgres://%s:%s@%s/?sslmode=%s", config.User, config.Password, config.Host, config.SSLMode)
-}
-
-func createSourceStringWithDbName(config *PgSQLConfig) string {
-	return fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=%s", config.User, config.Password, config.Host, config.DbName, config.SSLMode)
+func createSourceString(user, password, host, dbName, SSLMode string) string {
+	return fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=%s", user, password, host, dbName, SSLMode)
 }

--- a/samples/server/go-server/api/server/storage/pgsqlstore.go
+++ b/samples/server/go-server/api/server/storage/pgsqlstore.go
@@ -37,11 +37,11 @@ type pgSQLStore struct {
 }
 
 func NewPgSQLStore(config *PgSQLConfig) *pgSQLStore {
-	err := createDatabase(createSourceString(config), config.DbName)
+	err := createDatabase(createSourceString(config.User, config.Password, config.Host, "postgres", config.SSLMode), config.DbName)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	db, err := sql.Open("postgres", createSourceStringWithDbName(config))
+	db, err := sql.Open("postgres", createSourceString(config.User, config.Password, config.Host, config.DbName, config.SSLMode))
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/samples/server/go-server/api/server/storage/pgsqlstore_test.go
+++ b/samples/server/go-server/api/server/storage/pgsqlstore_test.go
@@ -24,7 +24,7 @@ import (
 func dropDatabase(t *testing.T, config *PgSQLConfig) {
 	t.Helper()
 	// Open database
-	source := createSourceString(config)
+	source := createSourceString(config.User, config.Password, config.Host, "postgres", config.SSLMode)
 	db, err := sql.Open("postgres", source)
 	if err != nil {
 		t.Fatalf("Failed to open database: %v", err)


### PR DESCRIPTION
Using a configuration with a user called something other than 'postgres' made grafeas unable to create the database during startup.

Fixes #173