### PR TITLE
fix grafeas_go phony target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build fmt test vet clean
+.PHONY: build fmt test vet clean grafeas_go
 
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 CLEAN := *~
@@ -27,7 +27,7 @@ test:
 vet:
 	@go tool vet ${SRC}
 
-v1alpha1/proto/grafeas.pb.go: .install.protoc-gen-go .install.grpc-gateway v1alpha1/proto/grafeas.proto
+grafeas_go: .install.protoc-gen-go .install.grpc-gateway v1alpha1/proto/grafeas.proto
 	protoc \
 		-I ./ \
 		-I ./include \
@@ -37,10 +37,6 @@ v1alpha1/proto/grafeas.pb.go: .install.protoc-gen-go .install.grpc-gateway v1alp
 	    --grpc-gateway_out=logtostderr=true:. \
         --swagger_out=logtostderr=true:. \
 	    v1alpha1/proto/grafeas.proto
-
-
-.PHONY: grafeas_go
-grafeas_go: v1alpha1/proto/grafeas.pb.go
 
 clean:
 	go clean ./...


### PR DESCRIPTION
The v1alpha1/proto/grafeas.pb.go target does not run its recipe again after an initial run since the target file and its prereqs always exist. The phony target that runs v1alpha1/proto/grafeas.pb.go doesn't work the way we intend, so make the protoc recipe a phony target.