### PR TITLE
marking some required fields for pkg msgs

### DIFF
--- a/v1beta1/proto/package.proto
+++ b/v1beta1/proto/package.proto
@@ -34,7 +34,7 @@ enum Architecture {
 // This represents a particular channel of distribution for a given package.
 // E.g., Debian's jessie-backports dpkg mirror.
 message Distribution {
-  // The cpe_uri in [cpe format](https://cpe.mitre.org/specification/)
+  // Required. The cpe_uri in [CPE format](https://cpe.mitre.org/specification/)
   // denoting the package manager version distributing a package.
   string cpe_uri = 1;
 
@@ -42,8 +42,7 @@ message Distribution {
   // built.
   Architecture architecture = 2;
 
-  // The latest available version of this package in this distribution
-  // channel.
+  // The latest available version of this package in this distribution channel.
   Version latest_version = 3;
 
   // A freeform string denoting the maintainer of this package.
@@ -74,7 +73,7 @@ message Location {
 // channels. E.g., glibc (aka libc6) is distributed by many, at various
 // versions.
 message Package {
-  // The name of the package.
+  // Required. Immutable. The name of the package.
   string name = 1;
 
   // The various channels by which a package is distributed.

--- a/v1beta1/proto/package.proto
+++ b/v1beta1/proto/package.proto
@@ -102,8 +102,10 @@ message Installation {
 message Version {
   // Used to correct mistakes in the version numbering scheme.
   int32 epoch = 1;
-  // The main part of the version name.
+
+  // Required. The main part of the version name.
   string name = 2;
+
   // The iteration of the package build from the above version.
   string revision = 3;
 
@@ -121,7 +123,7 @@ message Version {
     MAXIMUM = 3;
   };
 
-  // Distinguish between sentinel MIN/MAX versions and normal versions. If
-  // kind is not NORMAL, then the other fields are ignored.
+  // Required. Distinguish between sentinel MIN/MAX versions and normal
+  // versions. If kind is not NORMAL, then the other fields are ignored.
   VersionKind kind = 4;
 }


### PR DESCRIPTION
When these messages are used as inputs to the API these fields are required to be set.