### PR TITLE
Fix incorrect deletion in DeleteOperation (memory-store)

### DIFF
--- a/samples/server/go-server/api/server/storage/memstore.go
+++ b/samples/server/go-server/api/server/storage/memstore.go
@@ -303,7 +303,7 @@ func (m *memStore) DeleteOperation(pID, opID string) error {
 	if _, ok := m.opsByID[opName]; !ok {
 		return status.Error(codes.NotFound, fmt.Sprintf("Operation with name %q does not Exist", opName))
 	}
-	delete(m.occurrencesByID, opName)
+	delete(m.opsByID, opName)
 	return nil
 }
 

--- a/samples/server/go-server/api/server/storage/storager_test.go
+++ b/samples/server/go-server/api/server/storage/storager_test.go
@@ -390,6 +390,10 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 		if err := s.DeleteOperation(pID, oID); err != nil {
 			t.Errorf("DeleteOperation got %v, want success ", err)
 		}
+
+		if err := s.DeleteOperation(pID, oID); err == nil {
+			t.Error("Deleting an operation that was deleted, got success, want error")
+		}
 	})
 
 	t.Run("UpdateOperation", func(t *testing.T) {


### PR DESCRIPTION
The wrong dictionary entry is delete in the `DeleteOperation` method
(`occurrences` instead of `ops`).
Signed-off-by: Liron Levin <liron@twistlock.com>