### PR TITLE
Return empty page token for last response

### DIFF
--- a/samples/server/go-server/api/server/storage/embeddedstore.go
+++ b/samples/server/go-server/api/server/storage/embeddedstore.go
@@ -17,7 +17,6 @@ package storage
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/boltdb/bolt"
@@ -132,7 +131,7 @@ func (m *embeddedStore) ListProjects(filter string, pageSize int, pageToken stri
 	})
 	startPos := parsePageToken(pageToken, 0)
 	endPos := min(startPos+pageSize, len(projects))
-	return projects[startPos:endPos], strconv.Itoa(endPos), nil
+	return projects[startPos:endPos], nextPageToken(endPos, len(projects)), nil
 }
 
 // CreateOccurrence adds the specified occurrence to the embedded store
@@ -199,7 +198,7 @@ func (m *embeddedStore) ListOccurrences(pID, filters string, pageSize int, pageT
 	})
 	startPos := parsePageToken(pageToken, 0)
 	endPos := min(startPos+pageSize, len(os))
-	return os[startPos:endPos], strconv.Itoa(endPos), nil
+	return os[startPos:endPos], nextPageToken(endPos, len(os)), nil
 }
 
 // CreateNote adds the specified note to the embedded store
@@ -279,7 +278,7 @@ func (m *embeddedStore) ListNotes(pID, filters string, pageSize int, pageToken s
 	})
 	startPos := parsePageToken(pageToken, 0)
 	endPos := min(startPos+pageSize, len(ns))
-	return ns[startPos:endPos], strconv.Itoa(endPos), nil
+	return ns[startPos:endPos], nextPageToken(endPos, len(ns)), nil
 }
 
 // ListNoteOccurrences returns up to pageSize number of occcurrences on the particular note (nID)
@@ -306,7 +305,7 @@ func (m *embeddedStore) ListNoteOccurrences(pID, nID, filters string, pageSize i
 	})
 	startPos := parsePageToken(pageToken, 0)
 	endPos := min(startPos+pageSize, len(os))
-	return os[startPos:endPos], strconv.Itoa(endPos), nil
+	return os[startPos:endPos], nextPageToken(endPos, len(os)), nil
 }
 
 // GetOperation returns the operation with pID and oID
@@ -372,7 +371,7 @@ func (m *embeddedStore) ListOperations(pID, filters string, pageSize int, pageTo
 	})
 	startPos := parsePageToken(pageToken, 0)
 	endPos := min(startPos+pageSize, len(os))
-	return os[startPos:endPos], strconv.Itoa(endPos), nil
+	return os[startPos:endPos], nextPageToken(endPos, len(os)), nil
 }
 
 func (m *embeddedStore) update(bucket string, key string, new bool, pb proto.Message) error {

--- a/samples/server/go-server/api/server/storage/memstore.go
+++ b/samples/server/go-server/api/server/storage/memstore.go
@@ -96,7 +96,7 @@ func (m *memStore) ListProjects(filter string, pageSize int, pageToken string) (
 	})
 	startPos := parsePageToken(pageToken, 0)
 	endPos := min(startPos+pageSize, len(projects))
-	return projects[startPos:endPos], strconv.Itoa(endPos), nil
+	return projects[startPos:endPos], nextPageToken(endPos, len(projects)), nil
 }
 
 // CreateOccurrence adds the specified occurrence to the mem store
@@ -162,7 +162,7 @@ func (m *memStore) ListOccurrences(pID, filters string, pageSize int, pageToken 
 	})
 	startPos := parsePageToken(pageToken, 0)
 	endPos := min(startPos+pageSize, len(os))
-	return os[startPos:endPos], strconv.Itoa(endPos), nil
+	return os[startPos:endPos], nextPageToken(endPos, len(os)), nil
 }
 
 // CreateNote adds the specified note to the mem store
@@ -244,7 +244,7 @@ func (m *memStore) ListNotes(pID, filters string, pageSize int, pageToken string
 	})
 	startPos := parsePageToken(pageToken, 0)
 	endPos := min(startPos+pageSize, len(ns))
-	return ns[startPos:endPos], strconv.Itoa(endPos), nil
+	return ns[startPos:endPos], nextPageToken(endPos, len(ns)), nil
 }
 
 // ListNoteOccurrences returns up to pageSize number of occcurrences on the particular note (nID)
@@ -269,7 +269,7 @@ func (m *memStore) ListNoteOccurrences(pID, nID, filters string, pageSize int, p
 	})
 	startPos := parsePageToken(pageToken, 0)
 	endPos := min(startPos+pageSize, len(os))
-	return os[startPos:endPos], strconv.Itoa(endPos), nil
+	return os[startPos:endPos], nextPageToken(endPos, len(os)), nil
 }
 
 // GetOperation returns the operation with pID and oID
@@ -335,7 +335,7 @@ func (m *memStore) ListOperations(pID, filters string, pageSize int, pageToken s
 	})
 	startPos := parsePageToken(pageToken, 0)
 	endPos := min(startPos+pageSize, len(ops))
-	return ops[startPos:endPos], strconv.Itoa(endPos), nil
+	return ops[startPos:endPos], nextPageToken(endPos, len(ops)), nil
 }
 
 // Parses the page token to an int. Returns defaultValue if parsing fails
@@ -357,4 +357,12 @@ func min(a, b int) int {
 	} else {
 		return b
 	}
+}
+
+// nextPageToken returns the next page token (the next item index or empty if not more items are left)
+func nextPageToken(lastPage, total int) string {
+	if lastPage == total {
+		return ""
+	}
+	return strconv.Itoa(lastPage)
 }

--- a/samples/server/go-server/api/server/storage/queries.go
+++ b/samples/server/go-server/api/server/storage/queries.go
@@ -46,30 +46,39 @@ const (
 	insertProject = `INSERT INTO projects(name) VALUES ($1)`
 	projectExists = `SELECT EXISTS (SELECT 1 FROM projects WHERE name = $1)`
 	deleteProject = `DELETE FROM projects WHERE name = $1`
-	listProjects  = `SELECT id, name FROM projects WHERE id > $2 LIMIT $1`
+	listProjects  = `SELECT id, name FROM projects WHERE id > $1 LIMIT $2`
+	projectCount  = `SELECT COUNT(*) FROM projects`
 
 	insertOccurrence = `INSERT INTO occurrences(project_name, occurrence_name, note_id, data)
                       VALUES ($1, $2, (SELECT id FROM notes WHERE project_name = $3 AND note_name = $4), $5)`
 	searchOccurrence = `SELECT data FROM occurrences WHERE project_name = $1 AND occurrence_name = $2`
 	updateOccurrence = `UPDATE occurrences SET data = $3 WHERE project_name = $1 AND occurrence_name = $2`
 	deleteOccurrence = `DELETE FROM occurrences WHERE project_name = $1 AND occurrence_name = $2`
-	listOccurrences  = `SELECT id, data FROM occurrences WHERE project_name = $1 AND id > $3 LIMIT $2`
+	listOccurrences  = `SELECT id, data FROM occurrences WHERE project_name = $1 AND id > $2 LIMIT $3`
+	occurrenceCount  = `SELECT COUNT(*) FROM occurrences WHERE project_name = $1`
 
 	insertNote          = `INSERT INTO notes(project_name, note_name, data) VALUES ($1, $2, $3)`
 	searchNote          = `SELECT data FROM notes WHERE project_name = $1 AND note_name = $2`
 	updateNote          = `UPDATE notes SET data = $3 WHERE project_name = $1 AND note_name = $2`
 	deleteNote          = `DELETE FROM notes WHERE project_name = $1 AND note_name = $2`
-	listNotes           = `SELECT id, data FROM notes WHERE project_name = $1 AND id > $3 LIMIT $2`
+	listNotes           = `SELECT id, data FROM notes WHERE project_name = $1 AND id > $2 LIMIT $3`
+	noteCount           = `SELECT COUNT(*) FROM notes WHERE project_name = $1`
 	listNoteOccurrences = `SELECT o.id, o.data FROM occurrences as o, notes as n
 	                         WHERE n.id = o.note_id
 	                           AND n.project_name = $1
 	                           AND n.note_name = $2
-	                           AND o.id > $4
-	                           LIMIT $3`
+	                           AND o.id > $3
+	                           LIMIT $4`
+
+	noteOccurrencesCount = `SELECT COUNT(*) FROM occurrences as o, notes as n
+	                         WHERE n.id = o.note_id
+	                           AND n.project_name = $1
+	                           AND n.note_name = $2`
 
 	insertOperation = `INSERT INTO operations(project_name, operation_name, data) VALUES ($1, $2, $3)`
 	searchOperation = `SELECT data FROM operations WHERE project_name = $1 AND operation_name = $2`
 	deleteOperation = `DELETE FROM operations WHERE project_name = $1 AND operation_name = $2`
 	updateOperation = `UPDATE operations SET data = $3 WHERE project_name = $1 AND operation_name = $2`
-	listOperations  = `SELECT id, data FROM operations WHERE project_name = $1 AND id > $3 LIMIT $2`
+	listOperations  = `SELECT id, data FROM operations WHERE project_name = $1 AND id > $2 LIMIT $3`
+	operationsCnt   = `SELECT COUNT(*) FROM operations WHERE project_name = $1`
 )

--- a/samples/server/go-server/api/server/storage/storager_test.go
+++ b/samples/server/go-server/api/server/storage/storager_test.go
@@ -444,9 +444,12 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			wantProjectNames = append(wantProjectNames, name.FormatProject(pID))
 		}
 		filter := "filters_are_yet_to_be_implemented"
-		gotProjects, _, err := s.ListProjects(filter, 100, "")
+		gotProjects, pageToken, err := s.ListProjects(filter, 100, "")
 		if err != nil {
 			t.Fatalf("ListProjects got %v want success", err)
+		}
+		if pageToken != "" {
+			t.Errorf("Got %s want empty page token", pageToken)
 		}
 		if len(gotProjects) != 20 {
 			t.Errorf("ListProjects got %v projects, want 20", len(gotProjects))
@@ -481,9 +484,13 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			}
 			ops = append(ops, *o)
 		}
-		gotOs, _, err := s.ListOperations(findProject, "", 100, "")
+		gotOs, pageToken, err := s.ListOperations(findProject, "", 100, "")
 		if err != nil {
 			t.Fatalf("ListOperations got %v want success", err)
+		}
+
+		if pageToken != "" {
+			t.Errorf("Got %s want empty page token", pageToken)
 		}
 
 		if len(gotOs) != 5 {
@@ -642,9 +649,12 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			t.Fatalf("Got %s want %s", p.Name, name.FormatProject(pID2))
 		}
 		// Get projects again
-		gotProjects, _, err = s.ListProjects(filter, 100, lastPage)
+		gotProjects, pageToken, err := s.ListProjects(filter, 100, lastPage)
 		if err != nil {
 			t.Fatalf("ListProjects got %v want success", err)
+		}
+		if pageToken != "" {
+			t.Fatalf("Got %s want empty page token", pageToken)
 		}
 		if len(gotProjects) != 1 {
 			t.Errorf("ListProjects got %v projects, want 1", len(gotProjects))
@@ -692,9 +702,12 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			t.Fatalf("Got %s want %s", p.Name, name.FormatNote(pID, nID2))
 		}
 		// Get occurrences again
-		gotNotes, _, err = s.ListNotes(pID, filter, 100, lastPage)
+		gotNotes, pageToken, err := s.ListNotes(pID, filter, 100, lastPage)
 		if err != nil {
 			t.Fatalf("ListNotes got %v want success", err)
+		}
+		if pageToken != "" {
+			t.Errorf("Got %s want empty page token", pageToken)
 		}
 		if len(gotNotes) != 1 {
 			t.Errorf("ListNotes got %v notes, want 1", len(gotNotes))
@@ -747,9 +760,12 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			t.Fatalf("Got %s want %s", p.Name, name.FormatOccurrence(pID, oID2))
 		}
 		// Get occurrences again
-		gotOccurrences, _, err = s.ListOccurrences(pID, filter, 100, lastPage)
+		gotOccurrences, pageToken, err := s.ListOccurrences(pID, filter, 100, lastPage)
 		if err != nil {
 			t.Fatalf("ListOccurrences got %v want success", err)
+		}
+		if pageToken != "" {
+			t.Errorf("Got %s want empty page token", pageToken)
 		}
 		if len(gotOccurrences) != 1 {
 			t.Errorf("ListOccurrences got %v operations, want 1", len(gotOccurrences))
@@ -803,9 +819,12 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			t.Fatalf("Got %s want %s", p.Name, name.FormatOccurrence(pID, oID2))
 		}
 		// Get occurrences again
-		gotOccurrences, _, err = s.ListNoteOccurrences(nPID, nID, filter, 100, lastPage)
+		gotOccurrences, pageToken, err := s.ListNoteOccurrences(nPID, nID, filter, 100, lastPage)
 		if err != nil {
 			t.Fatalf("ListNoteOccurrences got %v want success", err)
+		}
+		if pageToken != "" {
+			t.Fatalf("Got %s want empty page token", pageToken)
 		}
 		if len(gotOccurrences) != 1 {
 			t.Errorf("ListNoteOccurrences got %v operations, want 1", len(gotOccurrences))
@@ -853,9 +872,12 @@ func doTestStorager(t *testing.T, createStore func(t *testing.T) (server.Storage
 			t.Fatalf("Got %s want %s", p.Name, name.FormatOperation(pID, oID2))
 		}
 		// Get operations again
-		gotOperations, _, err = s.ListOperations(pID, filter, 100, lastPage)
+		gotOperations, pageToken, err := s.ListOperations(pID, filter, 100, lastPage)
 		if err != nil {
 			t.Fatalf("ListOperations got %v want success", err)
+		}
+		if pageToken != "" {
+			t.Errorf("Got %s want empty page token", pageToken)
 		}
 		if len(gotOperations) != 1 {
 			t.Errorf("ListOperations got %v operations, want 1", len(gotOperations))


### PR DESCRIPTION
According to protobuf specification, the next token should be empty for
the last.
```go
	// The next pagination token in the list response. It should be used as
	// page_token for the following request. An empty value means no more result.
	NextPageToken        string   `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
```

Signed-off-by: Liron Levin <liron@twistlock.com>