### PR TITLE
Add batch APIs for notes and occurrences

### DIFF
--- a/samples/server/go-server/api/server/testing/testobjects.go
+++ b/samples/server/go-server/api/server/testing/testobjects.go
@@ -40,7 +40,7 @@ func Occurrence(pID, noteName string) *pb.Occurrence {
 				Severity:  vpb.Severity_HIGH,
 				CvssScore: 7.5,
 				PackageIssue: []*vpb.PackageIssue{
-					&vpb.PackageIssue{
+					{
 						SeverityName: "HIGH",
 						AffectedLocation: &vpb.VulnerabilityLocation{
 							CpeUri:  "cpe:/o:debian:debian_linux:8",


### PR DESCRIPTION
Add missing beta APIs for batch updates.
The current implementation reuses the storage APIs without doing a bulk
storage update.
If you think it is needed we can re-implement this code per storage
provider.

Signed-off-by: liron <liron@twistlock.com>