### PR TITLE
Fix TLS registration

### DIFF
--- a/samples/server/go-server/api/server/api/api.go
+++ b/samples/server/go-server/api/server/api/api.go
@@ -68,7 +68,7 @@ func Run(config *Config, storage *server.Storager) {
 		tcpMux      = cmux.New(l)
 	)
 
-	tlsConfig, err := tlsClientConfig(config.CertFile)
+	tlsConfig, err := tlsClientConfig(config.CAFile)
 	if err != nil {
 		log.Fatal("Failed to create tls config", err)
 	}


### PR DESCRIPTION
The wrong path is used to generate the TLS settings (leads to client connectivity problems).

Signed-off-by: liron <liron@twistlock.com>