### PR TITLE
Flattening vuln note details fixed location into the details. We did …

### DIFF
--- a/go/v1/api/note_test.go
+++ b/go/v1/api/note_test.go
@@ -853,7 +853,7 @@ func vulnzNote(t *testing.T) *gpb.Note {
 						SeverityName:    "CRITICAL",
 						AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 						AffectedPackage: "foobar",
-						AffectedVersion: &gpb.Version{
+						MinAffectedVersion: &gpb.Version{
 							Kind: gpb.Version_MINIMUM,
 						},
 						FixedVersion: &gpb.Version{

--- a/go/v1/api/note_test.go
+++ b/go/v1/api/note_test.go
@@ -850,9 +850,15 @@ func vulnzNote(t *testing.T) *gpb.Note {
 				Severity: gpb.Severity_CRITICAL,
 				Details: []*gpb.VulnerabilityNote_Detail{
 					{
-						CpeUri:       "cpe:/o:debian:debian_linux:7",
-						Package:      "debian",
-						SeverityName: "CRITICAL",
+						SeverityName:    "CRITICAL",
+						AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+						AffectedPackage: "foobar",
+						AffectedVersion: &gpb.Version{
+							Kind: gpb.Version_MINIMUM,
+						},
+						FixedVersion: &gpb.Version{
+							Kind: gpb.Version_MAXIMUM,
+						},
 					},
 				},
 			},

--- a/go/v1/api/occurrence_test.go
+++ b/go/v1/api/occurrence_test.go
@@ -795,7 +795,7 @@ func vulnzOcc(t *testing.T, pID, noteName, imageName string) *gpb.Occurrence {
 					{
 						AffectedCpeUri:  "cpe:/o:debian:debian_linux:8",
 						AffectedPackage: "abc",
-						AffectedVersion: &gpb.Version{
+						MinAffectedVersion: &gpb.Version{
 							Name: "0.2.0",
 							Kind: gpb.Version_NORMAL,
 						},
@@ -824,7 +824,7 @@ func invalidVulnzOcc(t *testing.T, pID, noteName string) *gpb.Occurrence {
 					{
 						AffectedCpeUri:  "cpe:/o:debian:debian_linux:8",
 						AffectedPackage: "abc",
-						AffectedVersion: &gpb.Version{
+						MinAffectedVersion: &gpb.Version{
 							Name: "0.2.0",
 							Kind: gpb.Version_NORMAL,
 						},

--- a/go/v1/api/occurrence_test.go
+++ b/go/v1/api/occurrence_test.go
@@ -791,7 +791,7 @@ func vulnzOcc(t *testing.T, pID, noteName, imageName string) *gpb.Occurrence {
 		NoteName:    noteName,
 		Details: &gpb.Occurrence_Vulnerability{
 			Vulnerability: &gpb.VulnerabilityOccurrence{
-				PackageIssue: []*gpb.PackageIssue{
+				PackageIssue: []*gpb.VulnerabilityOccurrence_PackageIssue{
 					{
 						AffectedCpeUri:  "cpe:/o:debian:debian_linux:8",
 						AffectedPackage: "abc",
@@ -802,7 +802,7 @@ func vulnzOcc(t *testing.T, pID, noteName, imageName string) *gpb.Occurrence {
 						FixedCpeUri:  "cpe:/o:debian:debian_linux:8",
 						FixedPackage: "abc",
 						FixedVersion: &gpb.Version{
-							Name: "0.2.0",
+							Name: "1.0.0",
 							Kind: gpb.Version_NORMAL,
 						},
 					},
@@ -820,7 +820,7 @@ func invalidVulnzOcc(t *testing.T, pID, noteName string) *gpb.Occurrence {
 		NoteName: noteName,
 		Details: &gpb.Occurrence_Vulnerability{
 			Vulnerability: &gpb.VulnerabilityOccurrence{
-				PackageIssue: []*gpb.PackageIssue{
+				PackageIssue: []*gpb.VulnerabilityOccurrence_PackageIssue{
 					{
 						AffectedCpeUri:  "cpe:/o:debian:debian_linux:8",
 						AffectedPackage: "abc",
@@ -831,7 +831,7 @@ func invalidVulnzOcc(t *testing.T, pID, noteName string) *gpb.Occurrence {
 						FixedCpeUri:  "cpe:/o:debian:debian_linux:8",
 						FixedPackage: "abc",
 						FixedVersion: &gpb.Version{
-							Name: "0.2.0",
+							Name: "1.0.0",
 							Kind: gpb.Version_NORMAL,
 						},
 					},

--- a/go/v1/api/validators/grafeas/grafeas_test.go
+++ b/go/v1/api/validators/grafeas/grafeas_test.go
@@ -106,9 +106,15 @@ func TestValidateNote(t *testing.T) {
 						Severity: gpb.Severity_CRITICAL,
 						Details: []*gpb.VulnerabilityNote_Detail{
 							&gpb.VulnerabilityNote_Detail{
-								CpeUri:       "cpe:/o:debian:debian_linux:7",
-								Package:      "debian",
-								SeverityName: "LOW",
+								SeverityName:    "LOW",
+								AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+								AffectedPackage: "debian",
+								AffectedVersion: &gpb.Version{
+									Kind: gpb.Version_MINIMUM,
+								},
+								FixedVersion: &gpb.Version{
+									Kind: gpb.Version_MAXIMUM,
+								},
 							},
 						},
 					},

--- a/go/v1/api/validators/grafeas/grafeas_test.go
+++ b/go/v1/api/validators/grafeas/grafeas_test.go
@@ -109,7 +109,7 @@ func TestValidateNote(t *testing.T) {
 								SeverityName:    "LOW",
 								AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 								AffectedPackage: "debian",
-								AffectedVersion: &gpb.Version{
+								MinAffectedVersion: &gpb.Version{
 									Kind: gpb.Version_MINIMUM,
 								},
 								FixedVersion: &gpb.Version{

--- a/go/v1/api/validators/vulnerability/vulnerability.go
+++ b/go/v1/api/validators/vulnerability/vulnerability.go
@@ -24,16 +24,22 @@ import (
 	gpb "github.com/grafeas/grafeas/proto/v1/grafeas_go_proto"
 )
 
-// ValidateNote validates that a vulnerability has all its required fields filled in.
+// ValidateNote validates that a vulnerability note has all its required fields filled in.
 func ValidateNote(v *gpb.VulnerabilityNote) []error {
 	errs := []error{}
 
-	for i, detail := range v.GetDetails() {
-		if detail == nil {
-			errs = append(errs, fmt.Errorf("details[%d] detail cannot be null", i))
-		} else {
-			for _, err := range validateVulnerabilityDetail(detail) {
-				errs = append(errs, fmt.Errorf("details[%d].%s", i, err))
+	if details := v.GetDetails(); details == nil {
+		errs = append(errs, errors.New("details is required"))
+	} else if len(details) == 0 {
+		errs = append(errs, errors.New("details requires at least 1 element"))
+	} else {
+		for i, detail := range details {
+			if detail == nil {
+				errs = append(errs, fmt.Errorf("details[%d] detail cannot be null", i))
+			} else {
+				for _, err := range validateVulnerabilityDetail(detail) {
+					errs = append(errs, fmt.Errorf("details[%d].%s", i, err))
+				}
 			}
 		}
 	}
@@ -44,48 +50,41 @@ func ValidateNote(v *gpb.VulnerabilityNote) []error {
 func validateVulnerabilityDetail(vd *gpb.VulnerabilityNote_Detail) []error {
 	errs := []error{}
 
-	if vd.GetCpeUri() == "" {
-		errs = append(errs, errors.New("cpe_uri is required"))
+	if vd.GetAffectedCpeUri() == "" {
+		errs = append(errs, errors.New("affected_cpe_uri is required"))
 	}
-	if vd.GetPackage() == "" {
-		errs = append(errs, errors.New("package is required"))
+	if vd.GetAffectedPackage() == "" {
+		errs = append(errs, errors.New("affected_package is required"))
 	}
-
-	if ver := vd.GetMinAffectedVersion(); ver != nil {
-		for _, err := range pkg.ValidateVersion(ver) {
-			errs = append(errs, fmt.Errorf("min_affected_version.%s", err))
-		}
-	}
-	if fl := vd.GetFixedLocation(); fl != nil {
-		for _, err := range validateVulnerabilityLocation(fl) {
-			errs = append(errs, fmt.Errorf("fixed_location.%s", err))
-		}
-	}
-
-	return errs
-}
-
-func validateVulnerabilityLocation(vl *gpb.VulnerabilityLocation) []error {
-	errs := []error{}
-
-	if vl.GetCpeUri() == "" {
-		errs = append(errs, errors.New("cpe_uri is required"))
-	}
-	if vl.GetPackage() == "" {
-		errs = append(errs, errors.New("package is required"))
-	}
-	if ver := vl.GetVersion(); ver == nil {
-		errs = append(errs, errors.New("version is required"))
+	if ver := vd.GetAffectedVersion(); ver == nil {
+		errs = append(errs, errors.New("affected_version is required"))
 	} else {
 		for _, err := range pkg.ValidateVersion(ver) {
-			errs = append(errs, fmt.Errorf("version.%s", err))
+			errs = append(errs, fmt.Errorf("affected_version.%s", err))
+		}
+	}
+
+	if ver := vd.GetFixedVersion(); ver == nil {
+		errs = append(errs, errors.New("fixed_version is required"))
+	} else {
+		for _, err := range pkg.ValidateVersion(ver) {
+			errs = append(errs, fmt.Errorf("fixed_version.%s", err))
+		}
+		if ver.Kind == gpb.Version_NORMAL {
+			if vd.GetFixedCpeUri() == "" {
+				errs = append(errs, errors.New("fixed_cpe_uri is required when fixed_version.kind is NORMAL"))
+			}
+			if vd.GetFixedPackage() == "" {
+				errs = append(errs, errors.New("fixed_package is required when fixed_version.kind is NORMAL"))
+			}
 		}
 	}
 
 	return errs
 }
 
-// ValidateOccurrence validates that a details has all its required fields filled in.
+// ValidateOccurrence validates that a vulnerability occurrence has all its required fields filled
+// in.
 func ValidateOccurrence(d *gpb.VulnerabilityOccurrence) []error {
 	errs := []error{}
 
@@ -108,7 +107,7 @@ func ValidateOccurrence(d *gpb.VulnerabilityOccurrence) []error {
 	return errs
 }
 
-func validatePackageIssue(p *gpb.PackageIssue) []error {
+func validatePackageIssue(p *gpb.VulnerabilityOccurrence_PackageIssue) []error {
 	errs := []error{}
 
 	if p.GetAffectedCpeUri() == "" {
@@ -121,7 +120,7 @@ func validatePackageIssue(p *gpb.PackageIssue) []error {
 		errs = append(errs, errors.New("affected_version is required"))
 	} else {
 		for _, err := range pkg.ValidateVersion(ver) {
-			errs = append(errs, fmt.Errorf("version.%s", err))
+			errs = append(errs, fmt.Errorf("affected_version.%s", err))
 		}
 	}
 
@@ -129,14 +128,14 @@ func validatePackageIssue(p *gpb.PackageIssue) []error {
 		errs = append(errs, errors.New("fixed_version is required"))
 	} else {
 		for _, err := range pkg.ValidateVersion(ver) {
-			errs = append(errs, fmt.Errorf("version.%s", err))
+			errs = append(errs, fmt.Errorf("fixed_version.%s", err))
 		}
 		if ver.Kind == gpb.Version_NORMAL {
 			if p.GetFixedCpeUri() == "" {
-				errs = append(errs, errors.New("fixed_cpe_uri is required when fixed_version kind is NORMAL"))
+				errs = append(errs, errors.New("fixed_cpe_uri is required when fixed_version.kind is NORMAL"))
 			}
 			if p.GetFixedPackage() == "" {
-				errs = append(errs, errors.New("fixed_package is required when fixed_version kind is NORMAL"))
+				errs = append(errs, errors.New("fixed_package is required when fixed_version.kind is NORMAL"))
 			}
 		}
 	}

--- a/go/v1/api/validators/vulnerability/vulnerability.go
+++ b/go/v1/api/validators/vulnerability/vulnerability.go
@@ -56,11 +56,11 @@ func validateVulnerabilityDetail(vd *gpb.VulnerabilityNote_Detail) []error {
 	if vd.GetAffectedPackage() == "" {
 		errs = append(errs, errors.New("affected_package is required"))
 	}
-	if ver := vd.GetAffectedVersion(); ver == nil {
-		errs = append(errs, errors.New("affected_version is required"))
+	if ver := vd.GetMinAffectedVersion(); ver == nil {
+		errs = append(errs, errors.New("min_affected_version is required"))
 	} else {
 		for _, err := range pkg.ValidateVersion(ver) {
-			errs = append(errs, fmt.Errorf("affected_version.%s", err))
+			errs = append(errs, fmt.Errorf("min_affected_version.%s", err))
 		}
 	}
 
@@ -116,11 +116,11 @@ func validatePackageIssue(p *gpb.VulnerabilityOccurrence_PackageIssue) []error {
 	if p.GetAffectedPackage() == "" {
 		errs = append(errs, errors.New("affected_package is required"))
 	}
-	if ver := p.GetAffectedVersion(); ver == nil {
-		errs = append(errs, errors.New("affected_version is required"))
+	if ver := p.GetMinAffectedVersion(); ver == nil {
+		errs = append(errs, errors.New("min_affected_version is required"))
 	} else {
 		for _, err := range pkg.ValidateVersion(ver) {
-			errs = append(errs, fmt.Errorf("affected_version.%s", err))
+			errs = append(errs, fmt.Errorf("min_affected_version.%s", err))
 		}
 	}
 

--- a/go/v1/api/validators/vulnerability/vulnerability_test.go
+++ b/go/v1/api/validators/vulnerability/vulnerability_test.go
@@ -71,7 +71,7 @@ func TestValidateNote(t *testing.T) {
 						SeverityName:    "LOW",
 						AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 						AffectedPackage: "debian",
-						AffectedVersion: &gpb.Version{
+						MinAffectedVersion: &gpb.Version{
 							Name: "1.1.2",
 							Kind: gpb.Version_NORMAL,
 						},
@@ -108,7 +108,7 @@ func TestValidateVulnerabilityDetail(t *testing.T) {
 			vd: &gpb.VulnerabilityNote_Detail{
 				SeverityName:    "LOW",
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Kind: gpb.Version_MINIMUM,
 				},
 				FixedVersion: &gpb.Version{
@@ -122,7 +122,7 @@ func TestValidateVulnerabilityDetail(t *testing.T) {
 			vd: &gpb.VulnerabilityNote_Detail{
 				SeverityName:   "LOW",
 				AffectedCpeUri: "cpe:/o:debian:debian_linux:7",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Kind: gpb.Version_MINIMUM,
 				},
 				FixedVersion: &gpb.Version{
@@ -146,10 +146,10 @@ func TestValidateVulnerabilityDetail(t *testing.T) {
 		{
 			desc: "invalid affected version, want error(s)",
 			vd: &gpb.VulnerabilityNote_Detail{
-				SeverityName:    "LOW",
-				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
-				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{},
+				SeverityName:       "LOW",
+				AffectedCpeUri:     "cpe:/o:debian:debian_linux:7",
+				AffectedPackage:    "foobar",
+				MinAffectedVersion: &gpb.Version{},
 				FixedVersion: &gpb.Version{
 					Kind: gpb.Version_MAXIMUM,
 				},
@@ -162,7 +162,7 @@ func TestValidateVulnerabilityDetail(t *testing.T) {
 				SeverityName:    "LOW",
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Kind: gpb.Version_MINIMUM,
 				},
 			},
@@ -174,7 +174,7 @@ func TestValidateVulnerabilityDetail(t *testing.T) {
 				SeverityName:    "LOW",
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Kind: gpb.Version_MINIMUM,
 				},
 				FixedVersion: &gpb.Version{},
@@ -187,7 +187,7 @@ func TestValidateVulnerabilityDetail(t *testing.T) {
 				SeverityName:    "LOW",
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Kind: gpb.Version_MINIMUM,
 				},
 				FixedPackage: "foobar",
@@ -204,7 +204,7 @@ func TestValidateVulnerabilityDetail(t *testing.T) {
 				SeverityName:    "LOW",
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Kind: gpb.Version_MINIMUM,
 				},
 				FixedCpeUri: "cpe:/o:debian:debian_linux:8",
@@ -221,7 +221,7 @@ func TestValidateVulnerabilityDetail(t *testing.T) {
 				SeverityName:    "LOW",
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Kind: gpb.Version_MINIMUM,
 				},
 				FixedCpeUri:  "cpe:/o:debian:debian_linux:7",
@@ -239,7 +239,7 @@ func TestValidateVulnerabilityDetail(t *testing.T) {
 				SeverityName:    "LOW",
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Kind: gpb.Version_MINIMUM,
 				},
 				FixedVersion: &gpb.Version{
@@ -311,7 +311,7 @@ func TestValidateOccurrence(t *testing.T) {
 					{
 						AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 						AffectedPackage: "foobar",
-						AffectedVersion: &gpb.Version{
+						MinAffectedVersion: &gpb.Version{
 							Name: "1.1.2",
 							Kind: gpb.Version_NORMAL,
 						},
@@ -350,7 +350,7 @@ func TestValidatePackageIssue(t *testing.T) {
 			desc: "missing affected CPE URI, want error(s)",
 			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},
@@ -367,7 +367,7 @@ func TestValidatePackageIssue(t *testing.T) {
 			desc: "missing affected package, want error(s)",
 			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri: "cpe:/o:debian:debian_linux:7",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},
@@ -397,11 +397,11 @@ func TestValidatePackageIssue(t *testing.T) {
 		{
 			desc: "invalid affected version, want error(s)",
 			p: &gpb.VulnerabilityOccurrence_PackageIssue{
-				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
-				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{},
-				FixedCpeUri:     "cpe:/o:debian:debian_linux:7",
-				FixedPackage:    "foobar",
+				AffectedCpeUri:     "cpe:/o:debian:debian_linux:7",
+				AffectedPackage:    "foobar",
+				MinAffectedVersion: &gpb.Version{},
+				FixedCpeUri:        "cpe:/o:debian:debian_linux:7",
+				FixedPackage:       "foobar",
 				FixedVersion: &gpb.Version{
 					Name: "2.0.0",
 					Kind: gpb.Version_NORMAL,
@@ -414,7 +414,7 @@ func TestValidatePackageIssue(t *testing.T) {
 			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "debian",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},
@@ -426,7 +426,7 @@ func TestValidatePackageIssue(t *testing.T) {
 			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "debian",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},
@@ -439,7 +439,7 @@ func TestValidatePackageIssue(t *testing.T) {
 			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},
@@ -456,7 +456,7 @@ func TestValidatePackageIssue(t *testing.T) {
 			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},
@@ -474,7 +474,7 @@ func TestValidatePackageIssue(t *testing.T) {
 			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},
@@ -492,7 +492,7 @@ func TestValidatePackageIssue(t *testing.T) {
 			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "foobar",
-				AffectedVersion: &gpb.Version{
+				MinAffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},

--- a/go/v1/api/validators/vulnerability/vulnerability_test.go
+++ b/go/v1/api/validators/vulnerability/vulnerability_test.go
@@ -27,6 +27,22 @@ func TestValidateNote(t *testing.T) {
 		wantErrs bool
 	}{
 		{
+			desc: "nil details, want error(s)",
+			v: &gpb.VulnerabilityNote{
+				Severity: gpb.Severity_CRITICAL,
+				Details:  nil,
+			},
+			wantErrs: true,
+		},
+		{
+			desc: "empty details, want error(s)",
+			v: &gpb.VulnerabilityNote{
+				Severity: gpb.Severity_CRITICAL,
+				Details:  []*gpb.VulnerabilityNote_Detail{},
+			},
+			wantErrs: true,
+		},
+		{
 			desc: "nil detail, want error(s)",
 			v: &gpb.VulnerabilityNote{
 				Severity: gpb.Severity_CRITICAL,
@@ -52,9 +68,16 @@ func TestValidateNote(t *testing.T) {
 				Severity: gpb.Severity_CRITICAL,
 				Details: []*gpb.VulnerabilityNote_Detail{
 					&gpb.VulnerabilityNote_Detail{
-						CpeUri:       "cpe:/o:debian:debian_linux:7",
-						Package:      "debian",
-						SeverityName: "LOW",
+						SeverityName:    "LOW",
+						AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+						AffectedPackage: "debian",
+						AffectedVersion: &gpb.Version{
+							Name: "1.1.2",
+							Kind: gpb.Version_NORMAL,
+						},
+						FixedVersion: &gpb.Version{
+							Kind: gpb.Version_MAXIMUM,
+						},
 					},
 				},
 			},
@@ -81,43 +104,147 @@ func TestValidateVulnerabilityDetail(t *testing.T) {
 		wantErrs bool
 	}{
 		{
-			desc:     "missing CPE URI, want error(s)",
-			vd:       &gpb.VulnerabilityNote_Detail{},
-			wantErrs: true,
-		},
-		{
-			desc: "missing package, want error(s)",
+			desc: "missing affected CPE URI, want error(s)",
 			vd: &gpb.VulnerabilityNote_Detail{
-				CpeUri: "cpe:/o:debian:debian_linux:7",
+				SeverityName:    "LOW",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{
+					Kind: gpb.Version_MINIMUM,
+				},
+				FixedVersion: &gpb.Version{
+					Kind: gpb.Version_MAXIMUM,
+				},
 			},
 			wantErrs: true,
 		},
 		{
-			desc: "invalid min affected version, want error(s)",
+			desc: "missing affected package, want error(s)",
 			vd: &gpb.VulnerabilityNote_Detail{
-				CpeUri:             "cpe:/o:debian:debian_linux:7",
-				Package:            "debian",
-				SeverityName:       "LOW",
-				MinAffectedVersion: &gpb.Version{},
+				SeverityName:   "LOW",
+				AffectedCpeUri: "cpe:/o:debian:debian_linux:7",
+				AffectedVersion: &gpb.Version{
+					Kind: gpb.Version_MINIMUM,
+				},
+				FixedVersion: &gpb.Version{
+					Kind: gpb.Version_MAXIMUM,
+				},
 			},
 			wantErrs: true,
 		},
 		{
-			desc: "invalid fixed located set, want error(s)",
+			desc: "missing affected version, want error(s)",
 			vd: &gpb.VulnerabilityNote_Detail{
-				CpeUri:        "cpe:/o:debian:debian_linux:7",
-				Package:       "debian",
-				SeverityName:  "LOW",
-				FixedLocation: &gpb.VulnerabilityLocation{},
+				SeverityName:    "LOW",
+				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				AffectedPackage: "foobar",
+				FixedVersion: &gpb.Version{
+					Kind: gpb.Version_MAXIMUM,
+				},
 			},
 			wantErrs: true,
 		},
 		{
-			desc: "valid vulnerability details, want success",
+			desc: "invalid affected version, want error(s)",
 			vd: &gpb.VulnerabilityNote_Detail{
-				CpeUri:       "cpe:/o:debian:debian_linux:7",
-				Package:      "debian",
-				SeverityName: "LOW",
+				SeverityName:    "LOW",
+				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{},
+				FixedVersion: &gpb.Version{
+					Kind: gpb.Version_MAXIMUM,
+				},
+			},
+			wantErrs: true,
+		},
+		{
+			desc: "missing fixed version, want error(s)",
+			vd: &gpb.VulnerabilityNote_Detail{
+				SeverityName:    "LOW",
+				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{
+					Kind: gpb.Version_MINIMUM,
+				},
+			},
+			wantErrs: true,
+		},
+		{
+			desc: "invalid fixed version, want error(s)",
+			vd: &gpb.VulnerabilityNote_Detail{
+				SeverityName:    "LOW",
+				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{
+					Kind: gpb.Version_MINIMUM,
+				},
+				FixedVersion: &gpb.Version{},
+			},
+			wantErrs: true,
+		},
+		{
+			desc: "fixed version NORMAL, but missing fixed CPE URI, want error(s)",
+			vd: &gpb.VulnerabilityNote_Detail{
+				SeverityName:    "LOW",
+				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{
+					Kind: gpb.Version_MINIMUM,
+				},
+				FixedPackage: "foobar",
+				FixedVersion: &gpb.Version{
+					Kind: gpb.Version_NORMAL,
+					Name: "1.7.2",
+				},
+			},
+			wantErrs: true,
+		},
+		{
+			desc: "fixed version NORMAL, but missing fixed package, want error(s)",
+			vd: &gpb.VulnerabilityNote_Detail{
+				SeverityName:    "LOW",
+				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{
+					Kind: gpb.Version_MINIMUM,
+				},
+				FixedCpeUri: "cpe:/o:debian:debian_linux:8",
+				FixedVersion: &gpb.Version{
+					Kind: gpb.Version_NORMAL,
+					Name: "1.7.2",
+				},
+			},
+			wantErrs: true,
+		},
+		{
+			desc: "valid vulnerability details with fixed version NORMAL, want success",
+			vd: &gpb.VulnerabilityNote_Detail{
+				SeverityName:    "LOW",
+				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{
+					Kind: gpb.Version_MINIMUM,
+				},
+				FixedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				FixedPackage: "foobar",
+				FixedVersion: &gpb.Version{
+					Kind: gpb.Version_NORMAL,
+					Name: "1.7.2",
+				},
+			},
+			wantErrs: false,
+		},
+		{
+			desc: "valid vulnerability details with fixed version MAXIMUM, want success",
+			vd: &gpb.VulnerabilityNote_Detail{
+				SeverityName:    "LOW",
+				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{
+					Kind: gpb.Version_MINIMUM,
+				},
+				FixedVersion: &gpb.Version{
+					Kind: gpb.Version_MAXIMUM,
+				},
 			},
 			wantErrs: false,
 		},
@@ -135,67 +262,6 @@ func TestValidateVulnerabilityDetail(t *testing.T) {
 	}
 }
 
-func TestValidateVulnerabilityLocation(t *testing.T) {
-	tests := []struct {
-		desc     string
-		vl       *gpb.VulnerabilityLocation
-		wantErrs bool
-	}{
-		{
-			desc:     "missing CPE URI, want error(s)",
-			vl:       &gpb.VulnerabilityLocation{},
-			wantErrs: true,
-		},
-		{
-			desc: "missing package, want error(s)",
-			vl: &gpb.VulnerabilityLocation{
-				CpeUri: "cpe:/o:debian:debian_linux:7",
-			},
-			wantErrs: true,
-		},
-		{
-			desc: "missing version, want error(s)",
-			vl: &gpb.VulnerabilityLocation{
-				CpeUri:  "cpe:/o:debian:debian_linux:7",
-				Package: "debian",
-			},
-			wantErrs: true,
-		},
-		{
-			desc: "version set, but invalid, want error(s)",
-			vl: &gpb.VulnerabilityLocation{
-				CpeUri:  "cpe:/o:debian:debian_linux:7",
-				Package: "debian",
-				Version: &gpb.Version{},
-			},
-			wantErrs: true,
-		},
-		{
-			desc: "version set and invalid, want success",
-			vl: &gpb.VulnerabilityLocation{
-				CpeUri:  "cpe:/o:debian:debian_linux:7",
-				Package: "debian",
-				Version: &gpb.Version{
-					Name: "1.1.2",
-					Kind: gpb.Version_NORMAL,
-				},
-			},
-			wantErrs: false,
-		},
-	}
-
-	for _, tt := range tests {
-		errs := validateVulnerabilityLocation(tt.vl)
-		t.Logf("%q: error(s): %v", tt.desc, errs)
-		if len(errs) == 0 && tt.wantErrs {
-			t.Errorf("%q: validateVulnerabilityLocation(%+v): got success, want error(s)", tt.desc, tt.vl)
-		}
-		if len(errs) > 0 && !tt.wantErrs {
-			t.Errorf("%q: validateVulnerabilityLocation(%+v): got error(s) %v, want success", tt.desc, tt.vl, errs)
-		}
-	}
-}
-
 func TestValidateOccurrence(t *testing.T) {
 	tests := []struct {
 		desc     string
@@ -203,50 +269,56 @@ func TestValidateOccurrence(t *testing.T) {
 		wantErrs bool
 	}{
 		{
-			desc:     "missing package issue, want error(s)",
-			d:        &gpb.VulnerabilityOccurrence{},
+			desc: "nil package issue, want error(s)",
+			d: &gpb.VulnerabilityOccurrence{
+				Severity:     gpb.Severity_CRITICAL,
+				PackageIssue: nil,
+			},
 			wantErrs: true,
 		},
 		{
 			desc: "empty package issue, want error(s)",
 			d: &gpb.VulnerabilityOccurrence{
-				PackageIssue: []*gpb.PackageIssue{},
+				Severity:     gpb.Severity_CRITICAL,
+				PackageIssue: []*gpb.VulnerabilityOccurrence_PackageIssue{},
 			},
 			wantErrs: true,
 		},
 		{
 			desc: "nil package issue element, want error(s)",
 			d: &gpb.VulnerabilityOccurrence{
-				PackageIssue: []*gpb.PackageIssue{nil},
-			},
-			wantErrs: true,
-		},
-		{
-			desc: "invalid package issue, want error(s)",
-			d: &gpb.VulnerabilityOccurrence{
-				PackageIssue: []*gpb.PackageIssue{
-					{
-						AffectedCpeUri: "cpe:/o:debian:debian_linux:7",
-					},
+				Severity: gpb.Severity_CRITICAL,
+				PackageIssue: []*gpb.VulnerabilityOccurrence_PackageIssue{
+					nil,
 				},
 			},
 			wantErrs: true,
 		},
 		{
-			desc: "valid details, want success",
+			desc: "invalid package issue element, want error(s)",
 			d: &gpb.VulnerabilityOccurrence{
-				PackageIssue: []*gpb.PackageIssue{
+				Severity: gpb.Severity_CRITICAL,
+				PackageIssue: []*gpb.VulnerabilityOccurrence_PackageIssue{
+					&gpb.VulnerabilityOccurrence_PackageIssue{},
+				},
+			},
+			wantErrs: true,
+		},
+		{
+			desc: "valid package issue, want success",
+			d: &gpb.VulnerabilityOccurrence{
+				PackageIssue: []*gpb.VulnerabilityOccurrence_PackageIssue{
 					{
 						AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
-						AffectedPackage: "debian",
+						AffectedPackage: "foobar",
 						AffectedVersion: &gpb.Version{
 							Name: "1.1.2",
 							Kind: gpb.Version_NORMAL,
 						},
 						FixedCpeUri:  "cpe:/o:debian:debian_linux:7",
-						FixedPackage: "debian",
+						FixedPackage: "foobar",
 						FixedVersion: &gpb.Version{
-							Name: "1.1.2",
+							Name: "2.0.0",
 							Kind: gpb.Version_NORMAL,
 						},
 					},
@@ -271,21 +343,21 @@ func TestValidateOccurrence(t *testing.T) {
 func TestValidatePackageIssue(t *testing.T) {
 	tests := []struct {
 		desc     string
-		p        *gpb.PackageIssue
+		p        *gpb.VulnerabilityOccurrence_PackageIssue
 		wantErrs bool
 	}{
 		{
-			desc: "missing affected cpe uri, want error(s)",
-			p: &gpb.PackageIssue{
-				AffectedPackage: "debian",
+			desc: "missing affected CPE URI, want error(s)",
+			p: &gpb.VulnerabilityOccurrence_PackageIssue{
+				AffectedPackage: "foobar",
 				AffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},
 				FixedCpeUri:  "cpe:/o:debian:debian_linux:7",
-				FixedPackage: "debian",
+				FixedPackage: "foobar",
 				FixedVersion: &gpb.Version{
-					Name: "1.1.2",
+					Name: "2.0.0",
 					Kind: gpb.Version_NORMAL,
 				},
 			},
@@ -293,7 +365,7 @@ func TestValidatePackageIssue(t *testing.T) {
 		},
 		{
 			desc: "missing affected package, want error(s)",
-			p: &gpb.PackageIssue{
+			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri: "cpe:/o:debian:debian_linux:7",
 				AffectedVersion: &gpb.Version{
 					Name: "1.1.2",
@@ -302,7 +374,7 @@ func TestValidatePackageIssue(t *testing.T) {
 				FixedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				FixedPackage: "debian",
 				FixedVersion: &gpb.Version{
-					Name: "1.1.2",
+					Name: "2.0.0",
 					Kind: gpb.Version_NORMAL,
 				},
 			},
@@ -310,47 +382,28 @@ func TestValidatePackageIssue(t *testing.T) {
 		},
 		{
 			desc: "missing affected version, want error(s)",
-			p: &gpb.PackageIssue{
+			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
-				AffectedPackage: "debian",
+				AffectedPackage: "foobar",
 				FixedCpeUri:     "cpe:/o:debian:debian_linux:7",
-				FixedPackage:    "debian",
+				FixedPackage:    "foobar",
 				FixedVersion: &gpb.Version{
-					Name: "1.1.2",
+					Name: "2.0.0",
 					Kind: gpb.Version_NORMAL,
 				},
 			},
 			wantErrs: true,
 		},
 		{
-			desc: "missing fixed cpe uri when version is NORMAL, want error(s)",
-			p: &gpb.PackageIssue{
+			desc: "invalid affected version, want error(s)",
+			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
-				AffectedPackage: "debian",
-				AffectedVersion: &gpb.Version{
-					Name: "1.1.2",
-					Kind: gpb.Version_NORMAL,
-				},
-				FixedPackage: "debian",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{},
+				FixedCpeUri:     "cpe:/o:debian:debian_linux:7",
+				FixedPackage:    "foobar",
 				FixedVersion: &gpb.Version{
-					Name: "1.1.2",
-					Kind: gpb.Version_NORMAL,
-				},
-			},
-			wantErrs: true,
-		},
-		{
-			desc: "missing fixed package when version is NORMAL, want error(s)",
-			p: &gpb.PackageIssue{
-				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
-				AffectedPackage: "debian",
-				AffectedVersion: &gpb.Version{
-					Name: "1.1.2",
-					Kind: gpb.Version_NORMAL,
-				},
-				FixedCpeUri: "cpe:/o:debian:debian_linux:7",
-				FixedVersion: &gpb.Version{
-					Name: "1.1.2",
+					Name: "2.0.0",
 					Kind: gpb.Version_NORMAL,
 				},
 			},
@@ -358,47 +411,92 @@ func TestValidatePackageIssue(t *testing.T) {
 		},
 		{
 			desc: "missing fixed version, want error(s)",
-			p: &gpb.PackageIssue{
+			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "debian",
 				AffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},
-				FixedCpeUri:  "cpe:/o:debian:debian_linux:7",
-				FixedPackage: "debian",
 			},
 			wantErrs: true,
 		},
 		{
-			desc: "valid package issue, want success",
-			p: &gpb.PackageIssue{
+			desc: "invalid fixed version, want error(s)",
+			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
 				AffectedPackage: "debian",
 				AffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},
-				FixedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				FixedVersion: &gpb.Version{},
+			},
+			wantErrs: true,
+		},
+		{
+			desc: "fixed version NORMAL, but missing fixed CPE URI, want error(s)",
+			p: &gpb.VulnerabilityOccurrence_PackageIssue{
+				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{
+					Name: "1.1.2",
+					Kind: gpb.Version_NORMAL,
+				},
 				FixedPackage: "debian",
 				FixedVersion: &gpb.Version{
+					Name: "2.0.0",
+					Kind: gpb.Version_NORMAL,
+				},
+			},
+			wantErrs: true,
+		},
+		{
+			desc: "fixed version NORMAL, but missing fixed package, want error(s)",
+			p: &gpb.VulnerabilityOccurrence_PackageIssue{
+				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{
 					Name: "1.1.2",
+					Kind: gpb.Version_NORMAL,
+				},
+				FixedCpeUri: "cpe:/o:debian:debian_linux:7",
+				FixedVersion: &gpb.Version{
+					Name: "2.0.0",
+					Kind: gpb.Version_NORMAL,
+				},
+			},
+			wantErrs: true,
+		},
+
+		{
+			desc: "valid package issue with fixed version NORMAL, want success",
+			p: &gpb.VulnerabilityOccurrence_PackageIssue{
+				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				AffectedPackage: "foobar",
+				AffectedVersion: &gpb.Version{
+					Name: "1.1.2",
+					Kind: gpb.Version_NORMAL,
+				},
+				FixedCpeUri:  "cpe:/o:debian:debian_linux:7",
+				FixedPackage: "foobar",
+				FixedVersion: &gpb.Version{
+					Name: "2.0.0",
 					Kind: gpb.Version_NORMAL,
 				},
 			},
 			wantErrs: false,
 		},
 		{
-			desc: "valid package issue with version MAXIMUM, want success",
-			p: &gpb.PackageIssue{
+			desc: "valid package issue with fixed version MAXIMUM, want success",
+			p: &gpb.VulnerabilityOccurrence_PackageIssue{
 				AffectedCpeUri:  "cpe:/o:debian:debian_linux:7",
-				AffectedPackage: "debian",
+				AffectedPackage: "foobar",
 				AffectedVersion: &gpb.Version{
 					Name: "1.1.2",
 					Kind: gpb.Version_NORMAL,
 				},
 				FixedVersion: &gpb.Version{
-					Name: "1.1.2",
 					Kind: gpb.Version_MAXIMUM,
 				},
 			},

--- a/proto/v1/vulnerability.proto
+++ b/proto/v1/vulnerability.proto
@@ -25,7 +25,7 @@ import "proto/v1/common.proto";
 import "proto/v1/cvss.proto";
 import "proto/v1/package.proto";
 
-// Note provider-assigned severity/impact ranking.
+// Note provider assigned severity/impact ranking.
 enum Severity {
   // Unknown.
   SEVERITY_UNSPECIFIED = 0;
@@ -41,54 +41,61 @@ enum Severity {
   CRITICAL = 5;
 }
 
-// Vulnerability provides metadata about a security vulnerability in a Note.
+// A security vulnerability that can be found in resources.
 message VulnerabilityNote {
-  // The CVSS score for this vulnerability.
+  // The CVSS score of this vulnerability. CVSS score is on a scale of 0 - 10
+  // where 0 indicates low severity and 10 indicates high severity.
   float cvss_score = 1;
 
-  // Note provider assigned impact of the vulnerability.
+  // The note provider assigned severity of this vulnerability.
   Severity severity = 2;
 
-  // All information about the package to specifically identify this
-  // vulnerability. One entry per (version range and cpe_uri) the package
-  // vulnerability has manifested in.
+  // Details of all known distros and and packages affected by this
+  // vulnerability.
   repeated Detail details = 3;
 
-  // Identifies all appearances of this vulnerability in the package for a
-  // specific distro/location. For example: glibc in
-  // cpe:/o:debian:debian_linux:8 for versions 2.1 - 2.2
+  // A detail for a distro and package affected by this vulnerability and its
+  // associated fix (if one is available).
   message Detail {
-    // Required. The CPE URI in
-    // [cpe format](https://cpe.mitre.org/specification/) in which the
-    // vulnerability manifests. Examples include distro or storage location for
-    // vulnerable jar.
-    string cpe_uri = 1;
+    // The distro assigned severity of this vulnerability.
+    string severity_name = 1;
 
-    // Required. The name of the package where the vulnerability was found.
-    string package = 2;
+    // A vendor-specific description of this vulnerability.
+    string description = 2;
 
-    // The min version of the package in which the vulnerability exists.
-    grafeas.v1.Version min_affected_version = 3;
+    // The type of package; whether native or non native (e.g., ruby gems,
+    // node.js packages, etc.).
+    string package_type = 3;
 
-    // The severity (eg: distro assigned severity) for this vulnerability.
-    string severity_name = 4;
+    // Required. The [CPE URI](https://cpe.mitre.org/specification/) this
+    // vulnerability affects.
+    string affected_cpe_uri = 4;
 
-    // A vendor-specific description of this note.
-    string description = 5;
+    // Required. The package this vulnerability affects.
+    string affected_package = 5;
 
-    // The fix for this specific package version.
-    VulnerabilityLocation fixed_location = 6;
+    // Required. The minimum version of the package this vulnerability affects.
+    grafeas.v1.Version affected_version = 6;
 
-    // The type of package; whether native or non native(ruby gems, node.js
-    // packages etc).
-    string package_type = 7;
+    // The [CPE URI](https://cpe.mitre.org/specification/) this vulnerability
+    // was fixed in. It is possible for this to be different from the
+    // affected_cpe_uri.
+    string fixed_cpe_uri = 7;
+
+    // The package this vulnerability was fixed in. It is possible for this to
+    // be different from the affected_package.
+    string fixed_package = 8;
+
+    // Required. The version of the package this vulnerability was fixed in.
+    // Setting this to VersionKind.MAXIMUM means no fix is yet available.
+    grafeas.v1.Version fixed_version = 9;
 
     // Whether this detail is obsolete. Occurrences are expected not to point to
     // obsolete details.
-    bool is_obsolete = 8;
+    bool is_obsolete = 10;
   }
 
-  // The full description of the CVSSv3.
+  // The full description of the CVSSv3 for this vulnerability.
   CVSSv3 cvss_v3 = 4;
 
   // Windows details get their own format because the information format and
@@ -98,29 +105,27 @@ message VulnerabilityNote {
   repeated WindowsDetail windows_details = 5;
 
   message WindowsDetail {
-    // Required. The CPE URI in
-    // [cpe format](https://cpe.mitre.org/specification/) in which the
-    // vulnerability manifests. Examples include distro or storage location for
-    // vulnerable jar.
+    // Required. The [CPE URI](https://cpe.mitre.org/specification/) this
+    // vulnerability affects.
     string cpe_uri = 1;
 
-    // Required. The name of the vulnerability.
+    // Required. The name of this vulnerability.
     string name = 2;
 
-    // The description of the vulnerability.
+    // The description of this vulnerability.
     string description = 3;
 
     // Required. The names of the KBs which have hotfixes to mitigate this
     // vulnerability. Note that there may be multiple hotfixes (and thus
     // multiple KBs) that mitigate a given vulnerability. Currently any listed
-    // kb's presence is considered a fix.
+    // KBs presence is considered a fix.
     repeated KnowledgeBase fixing_kbs = 4;
 
     message KnowledgeBase {
-      // The KB name (generally of the form KB[0-9]+ i.e. KB123456).
+      // The KB name (generally of the form KB[0-9]+ (e.g., KB123456)).
       string name = 1;
-      // A link to the KB in the Windows update catalog -
-      // https://www.catalog.update.microsoft.com/
+      // A link to the KB in the [Windows update catalog]
+      // (https://www.catalog.update.microsoft.com/).
       string url = 2;
     }
   }
@@ -128,23 +133,53 @@ message VulnerabilityNote {
   // Next free ID is 6.
 }
 
-// Details of a vulnerability Occurrence.
+// An occurrence of a severity vulnerability on a resource.
 message VulnerabilityOccurrence {
-  // The type of package; whether native or non native(ruby gems, node.js
-  // packages etc)
+  // The type of package; whether native or non native (e.g., ruby gems, node.js
+  // packages, etc.).
   string type = 1;
 
-  // Output only. The note provider assigned Severity of the vulnerability.
+  // Output only. The note provider assigned severity of this vulnerability.
   Severity severity = 2;
 
   // Output only. The CVSS score of this vulnerability. CVSS score is on a
-  // scale of 0-10 where 0 indicates low severity and 10 indicates high
+  // scale of 0 - 10 where 0 indicates low severity and 10 indicates high
   // severity.
   float cvss_score = 3;
 
   // Required. The set of affected locations and their fixes (if available)
   // within the associated resource.
   repeated PackageIssue package_issue = 4;
+
+  // A detail for a distro and package this vulnerability occurrence was found in
+  // and its associated fix (if one is available).
+  message PackageIssue {
+    // Required. The [CPE URI](https://cpe.mitre.org/specification/) this
+    // vulnerability was found in.
+    string affected_cpe_uri = 1;
+
+    // Required. The package this vulnerability was found in.
+    string affected_package = 2;
+
+    // Required. The minimum version of the package this vulnerability exists in.
+    grafeas.v1.Version affected_version = 3;
+
+    // The [CPE URI](https://cpe.mitre.org/specification/) this vulnerability was
+    // fixed in. It is possible for this to be different from
+    // the affected_cpe_uri.
+    string fixed_cpe_uri = 4;
+
+    // The package this vulnerability was fixed in. It is possible for this to be
+    // different from the affected_package.
+    string fixed_package = 5;
+
+    // Required. The version of the package this vulnerability was fixed in.
+    // Setting this to VersionKind.MAXIMUM means no fix is yet available.
+    grafeas.v1.Version fixed_version = 6;
+
+    // Output only. Whether a fix is available for this package.
+    bool fix_available = 7;
+  }
 
   // Output only. A one sentence description of this vulnerability.
   string short_description = 5;
@@ -155,55 +190,12 @@ message VulnerabilityOccurrence {
   // Output only. URLs related to this vulnerability.
   repeated grafeas.v1.RelatedUrl related_urls = 7;
 
-  // The distro assigned severity for this vulnerability when it is
-  // available, and note provider assigned severity when distro has not yet
-  // assigned a severity for this vulnerability.
+  // The distro assigned severity for this vulnerability when it is available,
+  // and note provider assigned severity when distro has not yet assigned a
+  // severity for this vulnerability.
   Severity effective_severity = 8;
 
-  // Output only. True if at least one of the affected packages
-  // has a fix available.
+  // Output only. Whether at least one of the affected packages has a fix
+  // available.
   bool fix_available = 9;
-}
-
-// This message wraps a package, version and cpe_uri affected by a vulnerability
-// and its associated fix (if one is available).
-message PackageIssue {
-  // Required. The CPE URI in [cpe format](https://cpe.mitre.org/specification/)
-  // format. Examples include distro or storage location for vulnerable jar.
-  string affected_cpe_uri = 1;
-
-  // Required. The package being described.
-  string affected_package = 2;
-
-  // Required. The affected version of the vulnerability.
-  grafeas.v1.Version affected_version = 3;
-
-  // The CPE URI in [cpe format](https://cpe.mitre.org/specification/)
-  // format. Examples include distro or storage location for vulnerable jar.
-  // It is possible for fixed_cpe_uri to be different from affected_cpe_uri.
-  string fixed_cpe_uri = 4;
-
-  // The package in which fix is available. It is possible for fixed_package
-  // to be different from affected_package.
-  string fixed_package = 5;
-
-  // Required. The fixed version of the vulnerability. Setting this to
-  // Version.MAXIMUM implies no fix is available.
-  grafeas.v1.Version fixed_version = 6;
-
-  // Required. True if at a fix is available for this package.
-  bool fix_available = 7;
-}
-
-// The location of the vulnerability.
-message VulnerabilityLocation {
-  // Required. The CPE URI in [cpe format](https://cpe.mitre.org/specification/)
-  // format. Examples include distro or storage location for vulnerable jar.
-  string cpe_uri = 1;
-
-  // Required. The package being described.
-  string package = 2;
-
-  // Required. The version of the package being described.
-  grafeas.v1.Version version = 3;
 }

--- a/proto/v1/vulnerability.proto
+++ b/proto/v1/vulnerability.proto
@@ -75,7 +75,7 @@ message VulnerabilityNote {
     string affected_package = 5;
 
     // Required. The minimum version of the package this vulnerability affects.
-    grafeas.v1.Version affected_version = 6;
+    grafeas.v1.Version min_affected_version = 6;
 
     // The [CPE URI](https://cpe.mitre.org/specification/) this vulnerability
     // was fixed in. It is possible for this to be different from the
@@ -161,8 +161,9 @@ message VulnerabilityOccurrence {
     // Required. The package this vulnerability was found in.
     string affected_package = 2;
 
-    // Required. The minimum version of the package this vulnerability exists in.
-    grafeas.v1.Version affected_version = 3;
+    // Required. The minimum version of the package this vulnerability exists
+    // in.
+    grafeas.v1.Version min_affected_version = 3;
 
     // The [CPE URI](https://cpe.mitre.org/specification/) this vulnerability was
     // fixed in. It is possible for this to be different from


### PR DESCRIPTION
…this for vuln occ package issues. This makes it easier to read.

Moved def of PackageIssue message into the vuln occurrence, since it's only used there. This matches the vuln note details def.

Cleaned up comments in the vuln proto file.