### PR TITLE
remove the "next_id" comments in protos

### DIFF
--- a/proto/v1/deployment.proto
+++ b/proto/v1/deployment.proto
@@ -63,6 +63,4 @@ message DeploymentOccurrence {
   }
   // Platform hosting this deployment.
   Platform platform = 7;
-
-  // next_id = 8;
 }

--- a/proto/v1/grafeas.proto
+++ b/proto/v1/grafeas.proto
@@ -213,8 +213,6 @@ message Occurrence {
     // Describes an attestation of an artifact.
     grafeas.v1.AttestationOccurrence attestation = 14;
   }
-
-  // next_id = 15;
 }
 
 // A type of analysis that can be done for a resource.
@@ -267,8 +265,6 @@ message Note {
     // A note describing an attestation role.
     grafeas.v1.AttestationNote attestation = 16;
   }
-
-  // next_id = 17;
 }
 
 // Request to get an occurrence.
@@ -293,8 +289,6 @@ message ListOccurrencesRequest {
 
   // Token to provide to skip to a particular spot in the list.
   string page_token = 4;
-
-  // next_id = 7;
 }
 
 // Response for listing occurrences.

--- a/proto/v1/provenance.proto
+++ b/proto/v1/provenance.proto
@@ -67,8 +67,6 @@ message BuildProvenance {
 
   // Version string of the builder at the time this build was executed.
   string builder_version = 13;
-
-  // next_id = 14
 }
 
 // Source describes the location of the source used for the build.

--- a/proto/v1/vulnerability.proto
+++ b/proto/v1/vulnerability.proto
@@ -128,8 +128,6 @@ message VulnerabilityNote {
       string url = 2;
     }
   }
-
-  // Next free ID is 6.
 }
 
 // An occurrence of a severity vulnerability on a resource.


### PR DESCRIPTION
We follow semantic versioning in Grafeas and breaking changes require a new API version (which means a new set of protos, so we can reset the numbering any way we want), so we don't have to worry about reserving proto tag values.