### PR TITLE
Fixed instructions for how to run the server with config

### DIFF
--- a/go/v1beta1/README.md
+++ b/go/v1beta1/README.md
@@ -12,7 +12,7 @@ go run main/main.go
 
 This will start the Grafeas gRPC and REST APIs on `localhost:8080`.
 
-To start grafeas with a custom configuration use the `--config` flag (e.g. `--config config.yaml`). See [`config.yaml.sample`](config.yaml.sample) that can be used as a starting point when creating your own config file.
+To start grafeas with a custom configuration use the `--config` flag (e.g. `--config config.yaml`). See [`config.yaml`](config.yaml) that can be used as a starting point when creating your own config file.
 
 ### Access REST API with curl
 

--- a/go/v1beta1/config.yaml
+++ b/go/v1beta1/config.yaml
@@ -1,0 +1,33 @@
+grafeas:
+  # Grafeas api server config
+  api:
+    # Endpoint address
+    address: "0.0.0.0:8080"
+    # PKI configuration (optional)
+    cafile: ca.crt
+    keyfile: ca.key
+    certfile: ca.crt
+    # CORS configuration (optional)
+    cors_allowed_origins:
+      # - "http://example.net"
+  # Supported storage types are "memstore" and "postgres"
+  storage_type: "memstore"
+  # Postgres options
+  # Note: due to storage_type being set to memstore, the below config is a
+  # no-op and only preserved here as an example.
+  postgres:
+    # Database host
+    host: "127.0.0.1:5432"
+    # Dabase name
+    dbname: "postgres"
+    # Database username
+    user: "postgres"
+    # Database password
+    password: "password"
+    # Valid sslmodes disable, allow, prefer, require, verify-ca, verify-full.
+    # See https://www.postgresql.org/docs/current/static/libpq-connect.html for details
+    sslmode: "require"
+    # 32-bit URL-safe base64 key used to encrypt pagination tokens
+    # If one is not provided, it will be generated.
+    # Multiple grafeas instances in the same cluster need the same value.
+    paginationkey:


### PR DESCRIPTION
Added the `config.yaml` file to be used as example.