### PR TITLE
Fixed CD flow for Grafeas helm chart

### DIFF
--- a/cloudbuild_release.yaml
+++ b/cloudbuild_release.yaml
@@ -7,5 +7,4 @@ steps:
     args: ["build", "-f", "grafeas-charts/Dockerfile",
            "-t", "us.gcr.io/grafeas/helm-release:$TAG_NAME", "."]
   - name: "us.gcr.io/grafeas/helm-release:$TAG_NAME"
-images: ["gcr.io/grafeas/grafeas-server:$TAG_NAME",
-]
+images: ["us.gcr.io/grafeas/grafeas-server:$TAG_NAME"]

--- a/grafeas-charts/Dockerfile
+++ b/grafeas-charts/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM gcr.io/gcp-runtimes/ubuntu_16_0_4 as runtime_deps
 
-RUN apt-get install --no-install-recommends --no-install-suggests -y \
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
         git
 
 ENV HELM_VERSION v2.8.1
@@ -26,4 +26,5 @@ WORKDIR /go/src/github.com/grafeas/grafeas
 
 COPY . .
 
-CMD ["./grafeas-charts/helm_release.sh"]
+RUN chmod +x helm_release.sh
+CMD ["./helm_release.sh"]


### PR DESCRIPTION
1. Added `apt-get update` to the CloudBuild config;
1. Added executable permissions on the script that's run by the grafeas helm release container.