### PR TITLE
Deploy through CloudBuild fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       # ensures the Grafeas server image can be built
       - run: docker build .
       # ensures helm release image can be built
-      - run: docker build -if Dockerfile_helm_release
+      - run: docker build -f Dockerfile_helm_release
       # specify any bash command here prefixed with `run: `
       - run: make build; make test
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       # ensures the Grafeas server image can be built
       - run: docker build .
       # ensures helm release image can be built
-      - run: docker build grafeas-charts/
+      - run: docker build -if Dockerfile_helm_release
       # specify any bash command here prefixed with `run: `
       - run: make build; make test
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,6 @@ jobs:
       - setup_remote_docker
       # ensures the Grafeas server image can be built
       - run: docker build .
-      # ensures helm release image can be built
-      - run: docker build -f Dockerfile_helm_release
       # specify any bash command here prefixed with `run: `
       - run: make build; make test
 workflows:

--- a/Dockerfile_helm_release
+++ b/Dockerfile_helm_release
@@ -22,6 +22,8 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}
     tar -zxvf helm-${HELM_VERSION}-linux-amd64.tar.gz && \
     mv linux-amd64/helm /usr/local/bin/helm
 
+WORKDIR /go/src/github.com/grafeas/grafeas
+
 COPY . .
 
 RUN ls $PWD

--- a/cloudbuild_release.yaml
+++ b/cloudbuild_release.yaml
@@ -4,7 +4,7 @@ steps:
     args: ["build", "-f", "Dockerfile",
            "-t", "us.gcr.io/grafeas/grafeas-server:$TAG_NAME", "."]
   - name: "gcr.io/cloud-builders/docker"
-    args: ["build", "-f", "grafeas-charts/Dockerfile",
+    args: ["build", "-f", "Dockerfile_helm_release",
            "-t", "us.gcr.io/grafeas/helm-release:$TAG_NAME", "."]
   - name: "us.gcr.io/grafeas/helm-release:$TAG_NAME"
 images: ["us.gcr.io/grafeas/grafeas-server:$TAG_NAME"]

--- a/grafeas-charts/Dockerfile
+++ b/grafeas-charts/Dockerfile
@@ -22,8 +22,6 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}
     tar -zxvf helm-${HELM_VERSION}-linux-amd64.tar.gz && \
     mv linux-amd64/helm /usr/local/bin/helm
 
-WORKDIR /go/src/github.com/grafeas/grafeas
-
 COPY . .
 
 RUN echo $PWD

--- a/grafeas-charts/Dockerfile
+++ b/grafeas-charts/Dockerfile
@@ -24,7 +24,6 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}
 
 COPY . .
 
-RUN echo $PWD
 RUN ls $PWD
-RUN chmod +x ./helm_release.sh
-CMD ["./helm_release.sh"]
+RUN ls grafeas-charts
+CMD ["./grafeas-charts/helm_release.sh"]


### PR DESCRIPTION
1. Moved `grafeas-charts/Dockerfile` to `./Dockerfile_helm_release`, for consistency of executing `docker build` on CircleCI and CloudBuild.
1. Removed (for now) testing on CircleCI of the helm deploy Dockerfile, as we'll be moving towards shared testing infrastructure in Grafeas and Kritis, and will potentially move away from CircleCI, at which point the `docker build` will be re-added for this file.