### PR TITLE
Added chmod +x to make the helm_release.sh executable

### DIFF
--- a/Dockerfile_helm_release
+++ b/Dockerfile_helm_release
@@ -26,6 +26,5 @@ WORKDIR /go/src/github.com/grafeas/grafeas
 
 COPY . .
 
-RUN ls $PWD
-RUN ls grafeas-charts
+RUN chmod +x grafeas-charts/helm_release.sh
 CMD ["./grafeas-charts/helm_release.sh"]


### PR DESCRIPTION
Latest CloudBuild run failed to run the script with:

```
time="2019-07-24T22:42:35Z" level=error msg="error waiting for container: context canceled"
docker: Error response from daemon: OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"./grafeas-charts/helm_release.sh\": permission denied": unknown.
Already have image: us.gcr.io/grafeas/helm-release:v0.1.0
```

Also, removed debugging statements.