### PR TITLE
Add CPE to the discovery occurrence for V1.

### DIFF
--- a/proto/v1/discovery.proto
+++ b/proto/v1/discovery.proto
@@ -73,4 +73,7 @@ message DiscoveryOccurrence {
   // details to show to the user. The LocalizedMessage is output only and
   // populated by the API.
   google.rpc.Status analysis_status_error = 3;
+
+  // The CPE of the resource being scanned.
+  string  cpe = 4;
 }


### PR DESCRIPTION
This is extremely useful for figuring out the operating system of a
resource without having to rely on sub occurrences which may not exist.