### PR TITLE
support for both existing and creation of secret for helm chart

### DIFF
--- a/grafeas-charts/templates/secrets.yaml
+++ b/grafeas-charts/templates/secrets.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.secret.enabled }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +14,4 @@ data:
   ca.crt: {{ .Values.certificates.ca | b64enc }}
   server.crt : {{ .Values.certificates.cert | b64enc }}
   server.key: {{ .Values.certificates.key | b64enc }}
+{{- end }}

--- a/grafeas-charts/values.yaml
+++ b/grafeas-charts/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
 
+secret:
+  enabled: false
+
 image:
   repository: us.gcr.io/grafeas
   name: grafeas-server


### PR DESCRIPTION
These changes are to easily allow the use of an existing generated secret and certs instead of generating them with the helm chart.