### PR TITLE
Effective severity should be output only.

### DIFF
--- a/proto/v1/vulnerability.proto
+++ b/proto/v1/vulnerability.proto
@@ -215,9 +215,8 @@ message VulnerabilityOccurrence {
   // Output only. URLs related to this vulnerability.
   repeated grafeas.v1.RelatedUrl related_urls = 7;
 
-  // The distro assigned severity for this vulnerability when it is available,
-  // and note provider assigned severity when distro has not yet assigned a
-  // severity for this vulnerability.
+  // Output only. The distro assigned severity for this vulnerability when it is
+  // available, otherwise this is the note provider assigned severity.
   Severity effective_severity = 8;
 
   // Output only. Whether at least one of the affected packages has a fix


### PR DESCRIPTION
It can be resolved at occurrence creation time from the note information and hence filled in during occurrence creation by the API.