### PR TITLE
Reverting output only comment on effective severity for now.

### DIFF
--- a/proto/v1/vulnerability.proto
+++ b/proto/v1/vulnerability.proto
@@ -215,8 +215,8 @@ message VulnerabilityOccurrence {
   // Output only. URLs related to this vulnerability.
   repeated grafeas.v1.RelatedUrl related_urls = 7;
 
-  // Output only. The distro assigned severity for this vulnerability when it is
-  // available, otherwise this is the note provider assigned severity.
+  // The distro assigned severity for this vulnerability when it is available,
+  // otherwise this is the note provider assigned severity.
   Severity effective_severity = 8;
 
   // Output only. Whether at least one of the affected packages has a fix


### PR DESCRIPTION
It's not clear it should be output only.