### PR TITLE
Add API config annotations

### DIFF
--- a/proto/v1beta1/grafeas.proto
+++ b/proto/v1beta1/grafeas.proto
@@ -22,6 +22,9 @@ option java_package = "io.grafeas.v1beta1";
 option objc_class_prefix = "GRA";
 
 import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
@@ -55,6 +58,7 @@ service GrafeasV1Beta1 {
     option (google.api.http) = {
       get: "/v1beta1/{name=projects/*/occurrences/*}"
     };
+    option (google.api.method_signature) = "name";
   };
 
   // Lists occurrences for the specified project.
@@ -63,6 +67,7 @@ service GrafeasV1Beta1 {
     option (google.api.http) = {
       get: "/v1beta1/{parent=projects/*}/occurrences"
     };
+    option (google.api.method_signature) = "parent,filter";
   };
 
   // Deletes the specified occurrence. For example, use this method to delete an
@@ -73,6 +78,7 @@ service GrafeasV1Beta1 {
     option (google.api.http) = {
       delete: "/v1beta1/{name=projects/*/occurrences/*}"
     };
+    option (google.api.method_signature) = "name";
   };
 
   // Creates a new occurrence.
@@ -81,6 +87,7 @@ service GrafeasV1Beta1 {
       post: "/v1beta1/{parent=projects/*}/occurrences"
       body: "occurrence"
     };
+    option (google.api.method_signature) = "parent,occurrence";
   };
 
   // Creates new occurrences in batch.
@@ -90,6 +97,7 @@ service GrafeasV1Beta1 {
       post: "/v1beta1/{parent=projects/*}/occurrences:batchCreate"
       body: "*"
     };
+    option (google.api.method_signature) = "parent,occurrences";
   };
 
   // Updates the specified occurrence.
@@ -98,6 +106,7 @@ service GrafeasV1Beta1 {
       patch: "/v1beta1/{name=projects/*/occurrences/*}"
       body: "occurrence"
     };
+    option (google.api.method_signature) = "name,occurrence,update_mask";
   };
 
   // Gets the note attached to the specified occurrence. Consumer projects can
@@ -106,6 +115,7 @@ service GrafeasV1Beta1 {
     option (google.api.http) = {
       get: "/v1beta1/{name=projects/*/occurrences/*}/notes"
     };
+    option (google.api.method_signature) = "name";
   };
 
   // Gets the specified note.
@@ -113,6 +123,7 @@ service GrafeasV1Beta1 {
     option (google.api.http) = {
       get: "/v1beta1/{name=projects/*/notes/*}"
     };
+    option (google.api.method_signature) = "name";
   };
 
   // Lists notes for the specified project.
@@ -120,6 +131,7 @@ service GrafeasV1Beta1 {
     option (google.api.http) = {
       get: "/v1beta1/{parent=projects/*}/notes"
     };
+    option (google.api.method_signature) = "parent,filter";
   };
 
   // Deletes the specified note.
@@ -127,6 +139,7 @@ service GrafeasV1Beta1 {
     option (google.api.http) = {
       delete: "/v1beta1/{name=projects/*/notes/*}"
     };
+    option (google.api.method_signature) = "name";
   };
 
   // Creates a new note.
@@ -135,6 +148,7 @@ service GrafeasV1Beta1 {
       post: "/v1beta1/{parent=projects/*}/notes"
       body: "note"
     };
+    option (google.api.method_signature) = "parent,note_id,note";
   };
 
   // Creates new notes in batch.
@@ -144,6 +158,7 @@ service GrafeasV1Beta1 {
       post: "/v1beta1/{parent=projects/*}/notes:batchCreate"
       body: "*"
     };
+    option (google.api.method_signature) = "parent,notes";
   };
 
   // Updates the specified note.
@@ -152,6 +167,7 @@ service GrafeasV1Beta1 {
       patch: "/v1beta1/{name=projects/*/notes/*}"
       body: "note"
     };
+    option (google.api.method_signature) = "name,note,update_mask";
   };
 
   // Lists occurrences referencing the specified note. Provider projects can use
@@ -162,6 +178,7 @@ service GrafeasV1Beta1 {
     option (google.api.http) = {
       get: "/v1beta1/{name=projects/*/notes/*}/occurrences"
     };
+    option (google.api.method_signature) = "name,filter";
   };
 
   // Gets a summary of the number and severity of occurrences.
@@ -171,11 +188,17 @@ service GrafeasV1Beta1 {
     option (google.api.http) = {
       get: "/v1beta1/{parent=projects/*}/occurrences:vulnerabilitySummary"
     };
+    option (google.api.method_signature) = "parent,filter";
   };
 };
 
 // An instance of an analysis type that has been found on a resource.
 message Occurrence {
+  option (google.api.resource) = {
+    type: "grafeas.grafeas.io/Occurrence"
+    pattern: "projects/{project}/occurrences/{occurrence}"
+  };
+
   // Output only. The name of the occurrence in the form of
   // `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
   string name = 1;
@@ -246,6 +269,11 @@ message Resource {
 
 // A type of analysis that can be done for a resource.
 message Note {
+  option (google.api.resource) = {
+    type: "grafeas.grafeas.io/Note"
+    pattern: "projects/{project}/notes/{note}"
+  };
+
   // Output only. The name of the note in the form of
   // `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
   string name = 1;
@@ -302,14 +330,20 @@ message Note {
 message GetOccurrenceRequest {
   // The name of the occurrence in the form of
   // `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
-  string name = 1;
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "grafeas.grafeas.io/Occurrence"
+  ];
 }
 
 // Request to list occurrences.
 message ListOccurrencesRequest {
   // The name of the project to list occurrences for in the form of
   // `projects/[PROJECT_ID]`.
-  string parent = 1;
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+  ];
 
   // The filter expression.
   string filter = 2;
@@ -338,25 +372,34 @@ message ListOccurrencesResponse {
 message DeleteOccurrenceRequest {
   // The name of the occurrence in the form of
   // `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
-  string name = 1;
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "grafeas.grafeas.io/Occurrence"
+  ];
 }
 
 // Request to create a new occurrence.
 message CreateOccurrenceRequest {
   // The name of the project in the form of `projects/[PROJECT_ID]`, under which
   // the occurrence is to be created.
-  string parent = 1;
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+  ];
   // The occurrence to create.
-  Occurrence occurrence = 2;
+  Occurrence occurrence = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Request to update an occurrence.
 message UpdateOccurrenceRequest {
   // The name of the occurrence in the form of
   // `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
-  string name = 1;
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "grafeas.grafeas.io/Occurrence"
+  ];
   // The updated occurrence.
-  Occurrence occurrence = 2;
+  Occurrence occurrence = 2 [(google.api.field_behavior) = REQUIRED];
   // The fields to update.
   google.protobuf.FieldMask update_mask = 3;
 }
@@ -365,21 +408,30 @@ message UpdateOccurrenceRequest {
 message GetNoteRequest {
   // The name of the note in the form of
   // `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
-  string name = 1;
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "grafeas.grafeas.io/Note"
+  ];
 }
 
 // Request to get the note to which the specified occurrence is attached.
 message GetOccurrenceNoteRequest {
   // The name of the occurrence in the form of
   // `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
-  string name = 1;
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "grafeas.grafeas.io/Occurrence"
+  ];
 }
 
 // Request to list notes.
 message ListNotesRequest {
   // The name of the project to list notes for in the form of
   // `projects/[PROJECT_ID]`.
-  string parent = 1;
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+  ];
 
   // The filter expression.
   string filter = 2;
@@ -406,27 +458,36 @@ message ListNotesResponse {
 message DeleteNoteRequest {
   // The name of the note in the form of
   // `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
-  string name = 1;
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "grafeas.grafeas.io/Note"
+  ];
 }
 
 // Request to create a new note.
 message CreateNoteRequest {
   // The name of the project in the form of `projects/[PROJECT_ID]`, under which
   // the note is to be created.
-  string parent = 1;
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+  ];
   // The ID to use for this note.
-  string note_id = 2;
+  string note_id = 2 [(google.api.field_behavior) = REQUIRED];
   // The note to create.
-  Note note = 3;
+  Note note = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Request to update a note.
 message UpdateNoteRequest {
   // The name of the note in the form of
   // `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
-  string name = 1;
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "grafeas.grafeas.io/Note"
+  ];
   // The updated note.
-  Note note = 2;
+  Note note = 2 [(google.api.field_behavior) = REQUIRED];
   // The fields to update.
   google.protobuf.FieldMask update_mask = 3;
 }
@@ -435,7 +496,10 @@ message UpdateNoteRequest {
 message ListNoteOccurrencesRequest {
   // The name of the note to list occurrences for in the form of
   // `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
-  string name = 1;
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "grafeas.grafeas.io/Note"
+  ];
   // The filter expression.
   string filter = 2;
   // Number of occurrences to return in the list.
@@ -456,10 +520,13 @@ message ListNoteOccurrencesResponse {
 message BatchCreateNotesRequest {
   // The name of the project in the form of `projects/[PROJECT_ID]`, under which
   // the notes are to be created.
-  string parent = 1;
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+  ];
 
   // The notes to create. Max allowed length is 1000.
-  map<string, Note> notes = 2;
+  map<string, Note> notes = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Response for creating notes in batch.
@@ -472,10 +539,13 @@ message BatchCreateNotesResponse {
 message BatchCreateOccurrencesRequest {
   // The name of the project in the form of `projects/[PROJECT_ID]`, under which
   // the occurrences are to be created.
-  string parent = 1;
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+  ];
 
   // The occurrences to create. Max allowed length is 1000.
-  repeated Occurrence occurrences = 2;
+  repeated Occurrence occurrences = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Response for creating occurrences in batch.
@@ -488,7 +558,10 @@ message BatchCreateOccurrencesResponse {
 message GetVulnerabilityOccurrencesSummaryRequest {
   // The name of the project to get a vulnerability summary for in the form of
   // `projects/[PROJECT_ID]`.
-  string parent = 1;
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+  ];
   // The filter expression.
   string filter = 2;
 }

--- a/proto/v1beta1/grafeas.proto
+++ b/proto/v1beta1/grafeas.proto
@@ -195,7 +195,7 @@ service GrafeasV1Beta1 {
 // An instance of an analysis type that has been found on a resource.
 message Occurrence {
   option (google.api.resource) = {
-    type: "grafeas.grafeas.io/Occurrence"
+    type: "grafeas.io/Occurrence"
     pattern: "projects/{project}/occurrences/{occurrence}"
   };
 
@@ -270,7 +270,7 @@ message Resource {
 // A type of analysis that can be done for a resource.
 message Note {
   option (google.api.resource) = {
-    type: "grafeas.grafeas.io/Note"
+    type: "grafeas.io/Note"
     pattern: "projects/{project}/notes/{note}"
   };
 
@@ -332,7 +332,7 @@ message GetOccurrenceRequest {
   // `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "grafeas.grafeas.io/Occurrence"
+    (google.api.resource_reference).type = "grafeas.io/Occurrence"
   ];
 }
 
@@ -374,7 +374,7 @@ message DeleteOccurrenceRequest {
   // `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "grafeas.grafeas.io/Occurrence"
+    (google.api.resource_reference).type = "grafeas.io/Occurrence"
   ];
 }
 
@@ -396,7 +396,7 @@ message UpdateOccurrenceRequest {
   // `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "grafeas.grafeas.io/Occurrence"
+    (google.api.resource_reference).type = "grafeas.io/Occurrence"
   ];
   // The updated occurrence.
   Occurrence occurrence = 2 [(google.api.field_behavior) = REQUIRED];
@@ -410,7 +410,7 @@ message GetNoteRequest {
   // `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "grafeas.grafeas.io/Note"
+    (google.api.resource_reference).type = "grafeas.io/Note"
   ];
 }
 
@@ -420,7 +420,7 @@ message GetOccurrenceNoteRequest {
   // `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "grafeas.grafeas.io/Occurrence"
+    (google.api.resource_reference).type = "grafeas.io/Occurrence"
   ];
 }
 
@@ -460,7 +460,7 @@ message DeleteNoteRequest {
   // `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "grafeas.grafeas.io/Note"
+    (google.api.resource_reference).type = "grafeas.io/Note"
   ];
 }
 
@@ -484,7 +484,7 @@ message UpdateNoteRequest {
   // `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "grafeas.grafeas.io/Note"
+    (google.api.resource_reference).type = "grafeas.io/Note"
   ];
   // The updated note.
   Note note = 2 [(google.api.field_behavior) = REQUIRED];
@@ -498,7 +498,7 @@ message ListNoteOccurrencesRequest {
   // `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "grafeas.grafeas.io/Note"
+    (google.api.resource_reference).type = "grafeas.io/Note"
   ];
   // The filter expression.
   string filter = 2;


### PR DESCRIPTION
This PR adds the API client config annotations per aip.dev, based on the [v1beta1/containeranalysis_gapic.yaml](https://github.com/googleapis/googleapis/blob/5af83f47b9656261cafcf88b0b3334521ab266b3/google/devtools/containeranalysis/v1beta1/containeranalysis_gapic.yaml). These annotations are used by client library generators to generate API client libraries. They are replacing the GAPIC config yaml file.

@vtsao this is the follow up PR to the internal CL.