### PR TITLE
add last_scan_time to discovery occurrences

### DIFF
--- a/proto/v1/discovery.proto
+++ b/proto/v1/discovery.proto
@@ -21,6 +21,7 @@ option java_multiple_files = true;
 option java_package = "io.grafeas.v1";
 option objc_class_prefix = "GRA";
 
+import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 import "proto/v1/common.proto";
 
@@ -76,4 +77,7 @@ message DiscoveryOccurrence {
 
   // The CPE of the resource being scanned.
   string  cpe = 4;
+  
+  // The last time this resource was scanned.
+  google.protobuf.Timestamp last_scan_time = 5;
 }


### PR DESCRIPTION
For things that are not continuously analyzed, it is valuable to report the last time a scan occurred.