### PR TITLE
add resource annotation to Project

### DIFF
--- a/proto/v1/grafeas.proto
+++ b/proto/v1/grafeas.proto
@@ -315,7 +315,7 @@ message ListOccurrencesRequest {
   // `projects/[PROJECT_ID]`.
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+    (google.api.resource_reference).type = "grafeas.io/Project"
   ];
 
   // The filter expression.
@@ -355,7 +355,7 @@ message CreateOccurrenceRequest {
   // the occurrence is to be created.
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+    (google.api.resource_reference).type = "grafeas.io/Project"
   ];
   // The occurrence to create.
   Occurrence occurrence = 2 [(google.api.field_behavior) = REQUIRED];
@@ -401,7 +401,7 @@ message ListNotesRequest {
   // `projects/[PROJECT_ID]`.
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+    (google.api.resource_reference).type = "grafeas.io/Project"
   ];
 
   // The filter expression.
@@ -441,7 +441,7 @@ message CreateNoteRequest {
   // the note is to be created.
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+    (google.api.resource_reference).type = "grafeas.io/Project"
   ];
   // The ID to use for this note.
   string note_id = 2 [(google.api.field_behavior) = REQUIRED];
@@ -493,7 +493,7 @@ message BatchCreateNotesRequest {
   // the notes are to be created.
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+    (google.api.resource_reference).type = "grafeas.io/Project"
   ];
 
   // The notes to create. Max allowed length is 1000.
@@ -512,7 +512,7 @@ message BatchCreateOccurrencesRequest {
   // the occurrences are to be created.
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
+    (google.api.resource_reference).type = "grafeas.io/Project"
   ];
 
   // The occurrences to create. Max allowed length is 1000.

--- a/proto/v1/project.proto
+++ b/proto/v1/project.proto
@@ -22,6 +22,7 @@ option java_package = "io.grafeas.v1.project";
 option objc_class_prefix = "GRA";
 
 import "google/api/annotations.proto";
+import "google/api/resource.proto";
 import "google/protobuf/empty.proto";
 
 // [Projects](https://grafeas.io) API.
@@ -68,7 +69,7 @@ message CreateProjectRequest {
 // Request to get a project.
 message GetProjectRequest {
   // The name of the project in the form of `projects/{PROJECT_ID}`.
-  string name = 1;
+  string name = 1 [(google.api.resource_reference).type = "grafeas.io/Project"];
 }
 
 // Request to list projects.
@@ -86,7 +87,7 @@ message ListProjectsRequest {
 // Request to delete a project.
 message DeleteProjectRequest {
   // The name of the project in the form of `projects/{PROJECT_ID}`.
-  string name = 1;
+  string name = 1 [(google.api.resource_reference).type = "grafeas.io/Project"];
 }
 
 // Response for listing projects.
@@ -102,6 +103,11 @@ message ListProjectsResponse {
 
 // Describes a Grafeas project.
 message Project {
+  option (google.api.resource) = {
+    type: "grafeas.io/Project"
+    pattern: "projects/{project}"
+  };
+
   // The name of the project in the form of `projects/{PROJECT_ID}`.
   string name = 1;
 }


### PR DESCRIPTION
As pointed out by https://github.com/googleapis/google-cloud-dotnet/issues/4102, Grafeas should not use the Google-specific Project resource definition, but rather its own. cc @jskeet

This annotates the `Project` message with the resource definition, adds resource references to GetProjectRequest and DeleteProjectRequest, and changes references of `cloudresourcemanager.googleapis.com/Project` to `grafeas.io/Project`.