### PR TITLE
Fixed CircleCI build that was failing due to newer images of PostgreSQL requiring a password.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
         environment:
           POSTGRES_DB: postgres
           POSTGRES_USER: postgres
-          POSTGRES_DB: password
+          POSTGRES_PASSWORD: password
     #### TEMPLATE_NOTE: go expects specific checkout path representing url
     #### expecting it in the form of
     ####   /go/src/github.com/circleci/go-tool


### PR DESCRIPTION
…QL requiring a password.

https://discuss.circleci.com/t/postgresql-image-password-not-specified-issue/34555