### PR TITLE
Generating pagination key when one is not provided by the configuration.

### DIFF
--- a/go/v1beta1/storage/pgsqlstore.go
+++ b/go/v1beta1/storage/pgsqlstore.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -41,41 +42,40 @@ type PgSQLStore struct {
 	paginationKey string
 }
 
-func NewPgSQLStore(config *config.PgSQLConfig) *PgSQLStore {
-	err := createDatabase(CreateSourceString(config.User, config.Password, config.Host, "postgres", config.SSLMode), config.DbName)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	db, err := sql.Open("postgres", CreateSourceString(config.User, config.Password, config.Host, config.DbName, config.SSLMode))
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	if db.Ping() != nil {
-		log.Fatal("Database server is not alive")
-	}
-	if _, err := db.Exec(createTables); err != nil {
-		db.Close()
-		log.Fatal(err.Error())
-	}
+func NewPgSQLStore(config *config.PgSQLConfig) (*PgSQLStore, error) {
 	paginationKey := config.PaginationKey
 	if paginationKey == "" {
 		log.Println("pagination key is empty, generating...")
 		var key fernet.Key
-		if err = key.Generate(); err != nil {
-			log.Fatal(err.Error())
+		if err := key.Generate(); err != nil {
+			return nil, errors.New(fmt.Sprintf("failed to generate pagination key, %s", err))
 		}
 		paginationKey = key.Encode()
 	} else {
 		// Validate pagination key
-		_, err = fernet.DecodeKey(paginationKey)
+		_, err := fernet.DecodeKey(paginationKey)
 		if err != nil {
-			log.Fatal("Invalid Pagination key; must be 32-bit URL-safe base64")
+			return nil, errors.New("invalid pagination key; must be 32-bit URL-safe base64")
 		}
+	}
+	if err := createDatabase(CreateSourceString(config.User, config.Password, config.Host, "postgres", config.SSLMode), config.DbName); err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("postgres", CreateSourceString(config.User, config.Password, config.Host, config.DbName, config.SSLMode))
+	if err != nil {
+		return nil, err
+	}
+	if db.Ping() != nil {
+		return nil, errors.New("database server is not alive")
+	}
+	if _, err := db.Exec(createTables); err != nil {
+		db.Close()
+		return nil, err
 	}
 	return &PgSQLStore{
 		DB:            db,
 		paginationKey: paginationKey,
-	}
+	}, nil
 }
 
 func createDatabase(source, dbName string) error {

--- a/go/v1beta1/storage/pgsqlstore.go
+++ b/go/v1beta1/storage/pgsqlstore.go
@@ -57,9 +57,24 @@ func NewPgSQLStore(config *config.PgSQLConfig) *PgSQLStore {
 		db.Close()
 		log.Fatal(err.Error())
 	}
+	paginationKey := config.PaginationKey
+	if paginationKey == "" {
+		log.Println("pagination key is empty, generating...")
+		var key fernet.Key
+		if err = key.Generate(); err != nil {
+			log.Fatal(err.Error())
+		}
+		paginationKey = key.Encode()
+	} else {
+		// Validate pagination key
+		_, err = fernet.DecodeKey(paginationKey)
+		if err != nil {
+			log.Fatal("Invalid Pagination key; must be 32-bit URL-safe base64")
+		}
+	}
 	return &PgSQLStore{
 		DB:            db,
-		paginationKey: config.PaginationKey,
+		paginationKey: paginationKey,
 	}
 }
 

--- a/go/v1beta1/storage/storagefactory.go
+++ b/go/v1beta1/storage/storagefactory.go
@@ -107,7 +107,11 @@ func postgresStorageTypeProvider(storageType string, storageConfig *config.Stora
 		return nil, errors.New(fmt.Sprintf("Unable to create PgSQLConfig, %s", err))
 	}
 
-	s := NewPgSQLStore(&storeConfig)
+	s, err := NewPgSQLStore(&storeConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	storage := &Storage{
 		Ps: s,
 		Gs: s,


### PR DESCRIPTION
Automatic generation of pagination key had been implemented in the past, but got removed during some refactoring. https://github.com/grafeas/grafeas/blob/cd06912f00d1f23b49ecb82f39e9283625b6ec87/go/config/config.go#L79

As an alternative we could make the pagination key a required field in the configuration file: 
https://github.com/grafeas/grafeas/blob/master/go/v1beta1/config.yaml#L33 but that seems heavy-handed.