### PR TITLE
chore(chart): update helm chart for option to disable persistence

### DIFF
--- a/grafeas-charts/templates/configmap.yaml
+++ b/grafeas-charts/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
 {{- end }}
         cors_allowed_origins:
         # - "http://example.net"
-      storage_type: {{ .Values.storageType }}
+      storage_type: {{ .Values.persistence.storageType }}
       embedded:
         # Path to embedded database
         path: "/data/grafeas.db"

--- a/grafeas-charts/templates/deployment.yaml
+++ b/grafeas-charts/templates/deployment.yaml
@@ -32,13 +32,15 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /etc/config
+{{- if .Values.persistence.enabled }}
 {{- if eq .Values.certificates.enabled true }}
           - name: certificates
             mountPath: /certificates
 {{- end }}
-{{- if eq .Values.storageType "embedded" }}
+{{- if eq .Values.persistence.storageType "embedded" }}
           - name: persistent-volume
             mountPath: /data
+{{- end }}
 {{- end }}
           resources:
 {{- toYaml .Values.resources | nindent 12 }}
@@ -61,14 +63,18 @@ spec:
             items:
             - key: config
               path: config.yaml
+{{- if .Values.persistence.enabled }}
+{{- if .Values.certificates.enabled }}
         - name: certificates
           secret:
             secretName: {{ .Values.certificates.name }}
-{{- if eq .Values.storageType "embedded" }}
+{{- end }}
+{{- if eq .Values.persistence.storageType "embedded" }}
         - name: persistent-volume
           persistentVolumeClaim:
-            claimName: {{ .Values.persistentVolumeClaimName }}
+            claimName: {{ .Values.persistence.claimName }}
 {{- end}}
+{{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/grafeas-charts/values.yaml
+++ b/grafeas-charts/values.yaml
@@ -3,6 +3,7 @@ replicaCount: 1
 secret:
   enabled: false
 
+## Grafeas image version
 image:
   repository: us.gcr.io/grafeas
   name: grafeas-server
@@ -12,20 +13,29 @@ image:
 nameOverride: "grafeas-server"
 fullnameOverride: "grafeas-server"
 
-# The name of persistent volume to use
-# persistent volume is used for storing the embedded grafeas data
-persistentVolumeClaimName: "grafeas"
-
-# The type of storage used, supported options: memstore or embedded
-# REMARK: embedded storage requires a persistent volume
-storageType: "memstore"
-
+## Specify a service type
+## ClusterIP is default
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
 service:
   type: ClusterIP
   port: 8080
 
 container:
   port: 8080
+
+## Persist data to a persistent volume. This is both a volume for certificates, Grafeas config and data volume.
+## enabled: false results in no persistent volumes and persistent volume claims being created
+## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+##
+persistence:
+  enabled: false
+  # The name of persistent volume to use
+  # persistent volume is used for storing the embedded grafeas data
+  claimName: "grafeas"
+  # The type of storage used, supported options: memstore or embedded
+  # REMARK: embedded storage requires a persistent volume
+  storageType: "memstore"
 
 # Certificates for mutual authentication
 certificates:
@@ -44,6 +54,8 @@ certificates:
       ...
       -----END RSA PRIVATE KEY-----
 
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources:
   limits:
     cpu: 100m
@@ -52,12 +64,17 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+## Customize liveness, readiness and startup probes
 livenessprobe:
-  initialDelaySeconds: 15 # Value based on pod startup average of ~12 seconds using default limits above
+  # Initial delay for liveness probe - value based on pod startup average of ~12 seconds using default resource limits above
+  initialDelaySeconds: 15
   periodSeconds: 10
-  failureThreshold: 3 # initialDelaySeconds + (failureThreshold * periodSeconds) based on worst case startup time of 45 seconds
+  # Failure threshold is calculated as initialDelaySeconds + (failureThreshold * periodSeconds) based on worst case startup time of 45 seconds
+  failureThreshold: 3
 
 readinessprobe:
-  initialDelaySeconds: 15 # Value based on pod startup average of ~12 seconds using default limits above
+  # Initial delay for readiness probe - value based on pod startup average of ~12 seconds using default resource limits above
+  initialDelaySeconds: 15
   periodSeconds: 10
-  failureThreshold: 3 # initialDelaySeconds + (failureThreshold * periodSeconds) based on worst case startup time of 45 seconds
+  # Failure threshold is calculated as initialDelaySeconds + (failureThreshold * periodSeconds) based on worst case startup time of 45 seconds
+  failureThreshold: 3


### PR DESCRIPTION
This PR is a partial restructure of the Grafeas helm chart and includes the following:
* Additional comments and references 
* Moving of fields under `persistence` field
* Option to disable `persistence` which will not create and PVs or PVCs other that config

For restricted environments, it's not inherently easy for the creation of PV and PVCs. The option to disable PVs and PVCs is a common one for many helm charts.

Open to thoughts and suggestions.