### PR TITLE
Validate public key IDs use an RFC3986 conformant

### DIFF
--- a/go/v1/api/validators/attestation/attestation.go
+++ b/go/v1/api/validators/attestation/attestation.go
@@ -19,6 +19,7 @@ package attestation
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	gpb "github.com/grafeas/grafeas/proto/v1/grafeas_go_proto"
 )
@@ -69,6 +70,8 @@ func validateSignatures(signatures []*gpb.Signature) []error {
 	for _, s := range signatures {
 		if s.GetPublicKeyId() == "" {
 			errs = append(errs, errors.New("public key ID is required"))
+		} else if !strings.ContainsRune(s.GetPublicKeyId(), ':') {
+			errs = append(errs, errors.New("public key ID must be an RFC3986 conformant URI"))
 		}
 		if s.GetSignature() == nil {
 			errs = append(errs, errors.New("signature is required"))

--- a/go/v1/api/validators/attestation/attestation_test.go
+++ b/go/v1/api/validators/attestation/attestation_test.go
@@ -117,7 +117,7 @@ func TestValidateOccurrence(t *testing.T) {
 				SerializedPayload: []byte("bar"),
 				Signatures: []*gpb.Signature{
 					{
-						PublicKeyId: "public-key",
+						PublicKeyId: "openpgp4fpr:74FAF3B861BDA0870C7B6DEF607E48D2A663AEEA",
 					},
 				},
 			},
@@ -130,10 +130,27 @@ func TestValidateOccurrence(t *testing.T) {
 				Signatures: []*gpb.Signature{
 					{
 						Signature:   []byte("foo"),
-						PublicKeyId: "public-key",
+						PublicKeyId: "openpgp4fpr:74FAF3B861BDA0870C7B6DEF607E48D2A663AEEA",
+					},
+					{
+						Signature:   []byte("foo"),
+						PublicKeyId: "ni:///sha-256;cD9o9Cq6LG3jD0iKXqEi_vdjJGecm_iXkbqVoScViaU",
 					},
 					{
 						Signature: []byte("foo"),
+					},
+				},
+			},
+			wantErrs: true,
+		},
+		{
+			desc: "invalid public key format, want errors",
+			a: &gpb.AttestationOccurrence{
+				SerializedPayload: []byte("bar"),
+				Signatures: []*gpb.Signature{
+					{
+						Signature:   []byte("foo"),
+						PublicKeyId: "74FAF3B861BDA0870C7B6DEF607E48D2A663AEEA",
 					},
 				},
 			},
@@ -146,7 +163,7 @@ func TestValidateOccurrence(t *testing.T) {
 				Signatures: []*gpb.Signature{
 					{
 						Signature:   []byte("foo"),
-						PublicKeyId: "public-key",
+						PublicKeyId: "openpgp4fpr:74FAF3B861BDA0870C7B6DEF607E48D2A663AEEA",
 					},
 				},
 			},


### PR DESCRIPTION
The spec (protobuf) specifies that keys MUST be RFC3986 conformant. This
patch adds a validator to ensure this.