### PR TITLE
batch 1.1: validation library; validation of CreateNoteRequest

### DIFF
--- a/go/v1/api/note.go
+++ b/go/v1/api/note.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/logger"
 	"github.com/grafeas/grafeas/go/name"
 	"github.com/grafeas/grafeas/go/v1/api/validators/grafeas"
+	vlib "github.com/grafeas/grafeas/go/validationlib"
 	gpb "github.com/grafeas/grafeas/proto/v1/grafeas_go_proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -40,6 +41,9 @@ func (g *API) CreateNote(ctx context.Context, req *gpb.CreateNoteRequest, resp *
 
 	if req.NoteId == "" {
 		return status.Errorf(codes.InvalidArgument, "a noteId must be specified")
+	}
+	if len(req.NoteId) > vlib.MaxNoteIDLength {
+		return status.Errorf(codes.InvalidArgument, fmt.Sprintf("The length of noteId must be <= %d", vlib.MaxNoteIDLength))
 	}
 	if req.Note == nil {
 		return status.Errorf(codes.InvalidArgument, "a note must be specified")

--- a/go/v1/api/note.go
+++ b/go/v1/api/note.go
@@ -45,6 +45,9 @@ func (g *API) CreateNote(ctx context.Context, req *gpb.CreateNoteRequest, resp *
 	if len(req.NoteId) > vlib.MaxNoteIDLength {
 		return status.Errorf(codes.InvalidArgument, fmt.Sprintf("The length of noteId must be <= %d", vlib.MaxNoteIDLength))
 	}
+	if !vlib.IsURLFriendly(req.NoteId) {
+		return status.Errorf(codes.InvalidArgument, "noteId must be URL friendly. See here: https://tools.ietf.org/html/rfc3986#appendix-A")
+	}
 	if req.Note == nil {
 		return status.Errorf(codes.InvalidArgument, "a note must be specified")
 	}

--- a/go/v1/api/note_test.go
+++ b/go/v1/api/note_test.go
@@ -91,6 +91,15 @@ func TestCreateNoteErrors(t *testing.T) {
 			wantErrStatus: codes.InvalidArgument,
 		},
 		{
+			desc: "note ID is not URL friendly",
+			req: &gpb.CreateNoteRequest{
+				Parent: "projects/goog-vulnz",
+				NoteId: "a@b",
+				Note:   vulnzNote(t),
+			},
+			wantErrStatus: codes.InvalidArgument,
+		},
+		{
 			desc: "nil note",
 			req: &gpb.CreateNoteRequest{
 				Parent: "projects/goog-vulnz",

--- a/go/v1/api/note_test.go
+++ b/go/v1/api/note_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
+	vlib "github.com/grafeas/grafeas/go/validationlib"
 	gpb "github.com/grafeas/grafeas/proto/v1/grafeas_go_proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -76,6 +77,15 @@ func TestCreateNoteErrors(t *testing.T) {
 			req: &gpb.CreateNoteRequest{
 				Parent: "projects/goog-vulnz",
 				NoteId: "",
+				Note:   vulnzNote(t),
+			},
+			wantErrStatus: codes.InvalidArgument,
+		},
+		{
+			desc: "length of note ID exceeds limit",
+			req: &gpb.CreateNoteRequest{
+				Parent: "projects/goog-vulnz",
+				NoteId: vlib.NewInputGenerator().GenStringAlpha(vlib.MaxNoteIDLength + 1),
 				Note:   vulnzNote(t),
 			},
 			wantErrStatus: codes.InvalidArgument,

--- a/go/v1beta1/api/grafeas.go
+++ b/go/v1beta1/api/grafeas.go
@@ -28,6 +28,7 @@ const (
 	defaultPageSize = 20
 	maxPageSize     = 1000
 	maxBatchSize    = 1000
+	maxNoteIDLength = 128
 
 	// NotesGet is the permission to get a note.
 	NotesGet = iam.Permission("notes.get")

--- a/go/v1beta1/api/grafeas.go
+++ b/go/v1beta1/api/grafeas.go
@@ -28,7 +28,6 @@ const (
 	defaultPageSize = 20
 	maxPageSize     = 1000
 	maxBatchSize    = 1000
-	maxNoteIDLength = 128
 
 	// NotesGet is the permission to get a note.
 	NotesGet = iam.Permission("notes.get")

--- a/go/v1beta1/api/note.go
+++ b/go/v1beta1/api/note.go
@@ -46,6 +46,9 @@ func (g *API) CreateNote(ctx context.Context, req *gpb.CreateNoteRequest) (*gpb.
 	if len(req.NoteId) > vlib.MaxNoteIDLength {
 		return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("The length of note_id must be <= %d", vlib.MaxNoteIDLength))
 	}
+	if !vlib.IsURLFriendly(req.NoteId) {
+		return nil, status.Errorf(codes.InvalidArgument, "noteId must be URL friendly. See here: https://tools.ietf.org/html/rfc3986#appendix-A")
+	}
 	if req.Note == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "a note must be specified")
 	}

--- a/go/v1beta1/api/note.go
+++ b/go/v1beta1/api/note.go
@@ -20,6 +20,7 @@ import (
 	emptypb "github.com/golang/protobuf/ptypes/empty"
 	"github.com/grafeas/grafeas/go/name"
 	"github.com/grafeas/grafeas/go/v1beta1/api/validators/grafeas"
+	vlib "github.com/grafeas/grafeas/go/validationlib"
 	gpb "github.com/grafeas/grafeas/proto/v1beta1/grafeas_go_proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -42,6 +43,11 @@ func (g *API) CreateNote(ctx context.Context, req *gpb.CreateNoteRequest) (*gpb.
 	if req.NoteId == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "a noteId must be specified")
 	}
+	if len(req.NoteId) > vlib.MaxNoteIDLength {
+		// TODO(test)
+		return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("The length of noteId must be <= %d", vlib.MaxNoteIDLength))
+	}
+
 	if req.Note == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "a note must be specified")
 	}

--- a/go/v1beta1/api/note.go
+++ b/go/v1beta1/api/note.go
@@ -44,10 +44,8 @@ func (g *API) CreateNote(ctx context.Context, req *gpb.CreateNoteRequest) (*gpb.
 		return nil, status.Errorf(codes.InvalidArgument, "a noteId must be specified")
 	}
 	if len(req.NoteId) > vlib.MaxNoteIDLength {
-		// TODO(test)
-		return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("The length of noteId must be <= %d", vlib.MaxNoteIDLength))
+		return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("The length of note_id must be <= %d", vlib.MaxNoteIDLength))
 	}
-
 	if req.Note == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "a note must be specified")
 	}

--- a/go/v1beta1/api/note_test.go
+++ b/go/v1beta1/api/note_test.go
@@ -95,6 +95,15 @@ func TestCreateNoteErrors(t *testing.T) {
 			wantErrStatus: codes.InvalidArgument,
 		},
 		{
+			desc: "note ID is not URL friendly",
+			req: &gpb.CreateNoteRequest{
+				Parent: "projects/goog-vulnz",
+				NoteId: "a@b",
+				Note:   vulnzNote(t),
+			},
+			wantErrStatus: codes.InvalidArgument,
+		},
+		{
 			desc: "nil note",
 			req: &gpb.CreateNoteRequest{
 				Parent: "projects/goog-vulnz",

--- a/go/v1beta1/api/note_test.go
+++ b/go/v1beta1/api/note_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
+	vlib "github.com/grafeas/grafeas/go/validationlib"
 	gpb "github.com/grafeas/grafeas/proto/v1beta1/grafeas_go_proto"
 	vpb "github.com/grafeas/grafeas/proto/v1beta1/vulnerability_go_proto"
 	"golang.org/x/net/context"
@@ -80,6 +81,15 @@ func TestCreateNoteErrors(t *testing.T) {
 			req: &gpb.CreateNoteRequest{
 				Parent: "projects/goog-vulnz",
 				NoteId: "",
+				Note:   vulnzNote(t),
+			},
+			wantErrStatus: codes.InvalidArgument,
+		},
+		{
+			desc: "length of note ID exceeds limit",
+			req: &gpb.CreateNoteRequest{
+				Parent: "projects/goog-vulnz",
+				NoteId: vlib.NewInputGenerator().GenStringAlpha(vlib.MaxNoteIDLength + 1),
 				Note:   vulnzNote(t),
 			},
 			wantErrStatus: codes.InvalidArgument,

--- a/go/validationlib/basic_check.go
+++ b/go/validationlib/basic_check.go
@@ -1,0 +1,58 @@
+// Copyright 2018 The Grafeas Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validationlib
+
+import (
+	"strings"
+)
+
+const (
+	// MaxNoteIDLength stands for the max length allowed for a note_id field.
+	MaxNoteIDLength = 128
+	// AlphaCharset accounts for alphabetic characters.
+	AlphaCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	// AlphaNumCharset accounts for the alphabetic and numeric characters.
+	AlphaNumCharset = AlphaCharset + "0123456789"
+	// URLFriendlyCharset accounts for the URL friendly characters.
+	// In more details, API style says that resource IDs should use URL-friendly
+	// resource IDs. See here: https://cloud.google.com/apis/design/resource_names#resource_id.
+	// The official spec allows ALPHA / DIGIT / "-" / "." / "_" / "~" as a subset
+	// See here: https://tools.ietf.org/html/rfc3986#appendix-A
+	URLFriendlyCharset = AlphaNumCharset + "-._~"
+)
+
+// IsAlpha checks whether s has alphabetic characters only.
+func IsAlpha(s string) bool {
+	// use the simple brutal force method which offers the reasonable complexity
+	// O(m*n) where m and n are the length of charset and input string.
+	for _, char := range s {
+		if !strings.Contains(AlphaCharset, string(char)) {
+			return false
+		}
+	}
+	return true
+}
+
+// IsURLFriendly checks whether s has URL friendly characters only.
+func IsURLFriendly(s string) bool {
+	// use the simple brutal force method which offers the reasonable complexity
+	// O(m*n) where m and n are the length of charset and input string.
+	for _, char := range s {
+		if !strings.Contains(URLFriendlyCharset, string(char)) {
+			return false
+		}
+	}
+	return true
+}

--- a/go/validationlib/basic_check_test.go
+++ b/go/validationlib/basic_check_test.go
@@ -1,0 +1,66 @@
+// Copyright 2018 The Grafeas Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validationlib
+
+import "testing"
+
+func TestIsAlpha(t *testing.T) {
+	// passing cases with input generator:
+	g := NewInputGenerator()
+	lengthToTest := []int{0, 10, 50, 100, 200, 500, 1000000}
+	for _, length := range lengthToTest {
+		tmpStr := g.GenStringAlpha(length)
+		if !IsAlpha(tmpStr) {
+			t.Errorf("%s is expected to be alphabetic only", tmpStr)
+		}
+	}
+
+	// failing cases:
+	badInputs := []string{"你好", "\b5Ὂg̀9! ℃ᾭG"}
+	for _, badInput := range badInputs {
+		if IsAlpha(badInput) {
+			t.Errorf("%s is expected to be not alphabetic only", badInput)
+		}
+	}
+}
+
+func TestIsURLFriendly(t *testing.T) {
+	// passing cases with input generator:
+	g := NewInputGenerator()
+	lengthToTest := []int{0, 10, 50, 100, 200, 500, 1000000}
+	for _, length := range lengthToTest {
+		tmpStr := g.GenStringURLFriendly(length)
+		if !IsURLFriendly(tmpStr) {
+			t.Errorf("%s is expected to be URL friendly", tmpStr)
+		}
+	}
+
+	// passing cases:
+	goodInputs := []string{"a~", "a-b", "a.b", "a_", "19a"}
+	for _, goodInput := range goodInputs {
+		if !IsURLFriendly(goodInput) {
+			t.Errorf("%s is expected to be URL friendly", goodInput)
+		}
+	}
+
+	// failing cases:
+	badInputs := []string{"你好", "a!", "a@", "a#", "a$", "a%", "a^",
+		"a&", "a*", "a(", "a)"}
+	for _, badInput := range badInputs {
+		if IsURLFriendly(badInput) {
+			t.Errorf("%s is expected to be not URL friendly", badInput)
+		}
+	}
+}

--- a/go/validationlib/input_gen.go
+++ b/go/validationlib/input_gen.go
@@ -1,0 +1,52 @@
+// Copyright 2018 The Grafeas Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validationlib
+
+import (
+	"math/rand"
+	"time"
+)
+
+// InputGenerator generates different types of inputs to be used in testing.
+type InputGenerator struct {
+	SeededRand *rand.Rand
+}
+
+// NewInputGenerator creates an InputGenerator instance and returns the pointer.
+func NewInputGenerator() *InputGenerator {
+	result := InputGenerator{
+		SeededRand: rand.New(
+			rand.NewSource(time.Now().UnixNano())),
+	}
+	return &result
+}
+
+// GenStringAlpha generates a string of specified length with the alphabetic character set.
+func (g *InputGenerator) GenStringAlpha(length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = AlphaCharset[g.SeededRand.Intn(len(AlphaCharset))]
+	}
+	return string(b)
+}
+
+// GenStringURLFriendly generates a string of specified length with the URL friendly character set.
+func (g *InputGenerator) GenStringURLFriendly(length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = URLFriendlyCharset[g.SeededRand.Intn(len(URLFriendlyCharset))]
+	}
+	return string(b)
+}

--- a/go/validationlib/input_gen_test.go
+++ b/go/validationlib/input_gen_test.go
@@ -1,0 +1,47 @@
+// Copyright 2018 The Grafeas Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validationlib
+
+import "testing"
+
+func TestGenStringAlpha(t *testing.T) {
+	g := NewInputGenerator()
+	lengthToTest := []int{0, 10, 50, 100, 200, 500, 1000000}
+	for _, length := range lengthToTest {
+		tmpStr := g.GenStringAlpha(length)
+		if len(tmpStr) != length {
+			t.Errorf("length of generated string %s != expected length %d", tmpStr, length)
+		}
+
+		if !IsAlpha(tmpStr) {
+			t.Errorf("%s is expected to be alphabetic only", tmpStr)
+		}
+	}
+}
+
+func TestGenStringURLFriendly(t *testing.T) {
+	g := NewInputGenerator()
+	lengthToTest := []int{0, 10, 50, 100, 200, 500, 1000000}
+	for _, length := range lengthToTest {
+		tmpStr := g.GenStringURLFriendly(length)
+		if len(tmpStr) != length {
+			t.Errorf("length of generated string %s != expected length %d", tmpStr, length)
+		}
+
+		if !IsURLFriendly(tmpStr) {
+			t.Errorf("%s is expected to be URL friendly", tmpStr)
+		}
+	}
+}

--- a/proto/v1/generate.go
+++ b/proto/v1/generate.go
@@ -1,5 +1,7 @@
 // This generates the protocol buffer code in go for the v1 proto spec.
 
+package v1
+
 //go:generate rm -rf grafeas_go_proto
 //go:generate mkdir grafeas_go_proto
 //go:generate -command protoc ../../protoc/bin/protoc -I ../../ -I ./ -I ../../protodeps/grpc-gateway/third_party/googleapis -I ../../protodeps/grpc-gateway -I ../../protodeps/googleapis --go_out=plugins=grpc,paths=source_relative:.  --grpc-gateway_out=logtostderr=true,paths=source_relative:.
@@ -28,4 +30,3 @@
 //go:generate mv vulnerability.pb.go grafeas_go_proto
 //go:generate protoc upgrade.proto
 //go:generate mv upgrade.pb.go grafeas_go_proto
-package v1

--- a/proto/v1/grafeas.proto
+++ b/proto/v1/grafeas.proto
@@ -444,6 +444,7 @@ message CreateNoteRequest {
     (google.api.resource_reference).type = "grafeas.io/Project"
   ];
   // The ID to use for this note.
+  // constraint: length <= 128.
   string note_id = 2 [(google.api.field_behavior) = REQUIRED];
   // The note to create.
   Note note = 3 [(google.api.field_behavior) = REQUIRED];

--- a/proto/v1/grafeas.proto
+++ b/proto/v1/grafeas.proto
@@ -445,6 +445,11 @@ message CreateNoteRequest {
   ];
   // The ID to use for this note.
   // constraint: length <= 128.
+  // constraint: note_id needs to be URL friendly.
+  // In more details, API style says that resource IDs should use URL-friendly
+	// resource IDs. See here: https://cloud.google.com/apis/design/resource_names#resource_id.
+	// The official spec allows ALPHA / DIGIT / "-" / "." / "_" / "~" as a subset
+	// See here: https://tools.ietf.org/html/rfc3986#appendix-A
   string note_id = 2 [(google.api.field_behavior) = REQUIRED];
   // The note to create.
   Note note = 3 [(google.api.field_behavior) = REQUIRED];

--- a/proto/v1beta1/grafeas.proto
+++ b/proto/v1beta1/grafeas.proto
@@ -478,6 +478,7 @@ message CreateNoteRequest {
     (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Project"
   ];
   // The ID to use for this note.
+  // constraint: length <= 128.
   string note_id = 2 [(google.api.field_behavior) = REQUIRED];
   // The note to create.
   Note note = 3 [(google.api.field_behavior) = REQUIRED];

--- a/proto/v1beta1/grafeas.proto
+++ b/proto/v1beta1/grafeas.proto
@@ -479,6 +479,11 @@ message CreateNoteRequest {
   ];
   // The ID to use for this note.
   // constraint: length <= 128.
+  // constraint: note_id needs to be URL friendly.
+  // In more details, API style says that resource IDs should use URL-friendly
+	// resource IDs. See here: https://cloud.google.com/apis/design/resource_names#resource_id.
+	// The official spec allows ALPHA / DIGIT / "-" / "." / "_" / "~" as a subset
+	// See here: https://tools.ietf.org/html/rfc3986#appendix-A
   string note_id = 2 [(google.api.field_behavior) = REQUIRED];
   // The note to create.
   Note note = 3 [(google.api.field_behavior) = REQUIRED];

--- a/proto/v1beta1/grafeas_go_proto/grafeas.pb.go
+++ b/proto/v1beta1/grafeas_go_proto/grafeas.pb.go
@@ -1173,6 +1173,7 @@ type CreateNoteRequest struct {
 	// the note is to be created.
 	Parent string `protobuf:"bytes,1,opt,name=parent,proto3" json:"parent,omitempty"`
 	// The ID to use for this note.
+	// constraint: length <= 128.
 	NoteId string `protobuf:"bytes,2,opt,name=note_id,json=noteId,proto3" json:"note_id,omitempty"`
 	// The note to create.
 	Note                 *Note    `protobuf:"bytes,3,opt,name=note,proto3" json:"note,omitempty"`

--- a/proto/v1beta1/vulnerability_go_proto/vulnerability.pb.go
+++ b/proto/v1beta1/vulnerability_go_proto/vulnerability.pb.go
@@ -379,8 +379,10 @@ type Vulnerability_WindowsDetail_KnowledgeBase struct {
 func (m *Vulnerability_WindowsDetail_KnowledgeBase) Reset() {
 	*m = Vulnerability_WindowsDetail_KnowledgeBase{}
 }
-func (m *Vulnerability_WindowsDetail_KnowledgeBase) String() string { return proto.CompactTextString(m) }
-func (*Vulnerability_WindowsDetail_KnowledgeBase) ProtoMessage()    {}
+func (m *Vulnerability_WindowsDetail_KnowledgeBase) String() string {
+	return proto.CompactTextString(m)
+}
+func (*Vulnerability_WindowsDetail_KnowledgeBase) ProtoMessage() {}
 func (*Vulnerability_WindowsDetail_KnowledgeBase) Descriptor() ([]byte, []int) {
 	return fileDescriptor_830da5652503f730, []int{0, 1, 0}
 }


### PR DESCRIPTION
batch 1 in validation improvement, step 1:
- add initial library support, this library will grow on demand.
     - [see go/ validationlib] 

    - [ basic_check for checking basic units]

    - [ input_gen for generating test inputs]  

- add validation of createnoterequest in v1 and v1beta.
    - check note_id, length <= 128
    - check note_id, format should be URL friendly. 
         - update the proto comment
         - update code & test.
