### PR TITLE
Revert "Validate public key IDs use an RFC3986 conformant"

### DIFF
--- a/go/v1/api/validators/attestation/attestation.go
+++ b/go/v1/api/validators/attestation/attestation.go
@@ -19,7 +19,6 @@ package attestation
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	gpb "github.com/grafeas/grafeas/proto/v1/grafeas_go_proto"
 )
@@ -70,8 +69,6 @@ func validateSignatures(signatures []*gpb.Signature) []error {
 	for _, s := range signatures {
 		if s.GetPublicKeyId() == "" {
 			errs = append(errs, errors.New("public key ID is required"))
-		} else if !strings.ContainsRune(s.GetPublicKeyId(), ':') {
-			errs = append(errs, errors.New("public key ID must be an RFC3986 conformant URI"))
 		}
 		if s.GetSignature() == nil {
 			errs = append(errs, errors.New("signature is required"))

--- a/go/v1/api/validators/attestation/attestation_test.go
+++ b/go/v1/api/validators/attestation/attestation_test.go
@@ -117,7 +117,7 @@ func TestValidateOccurrence(t *testing.T) {
 				SerializedPayload: []byte("bar"),
 				Signatures: []*gpb.Signature{
 					{
-						PublicKeyId: "openpgp4fpr:74FAF3B861BDA0870C7B6DEF607E48D2A663AEEA",
+						PublicKeyId: "public-key",
 					},
 				},
 			},
@@ -130,27 +130,10 @@ func TestValidateOccurrence(t *testing.T) {
 				Signatures: []*gpb.Signature{
 					{
 						Signature:   []byte("foo"),
-						PublicKeyId: "openpgp4fpr:74FAF3B861BDA0870C7B6DEF607E48D2A663AEEA",
-					},
-					{
-						Signature:   []byte("foo"),
-						PublicKeyId: "ni:///sha-256;cD9o9Cq6LG3jD0iKXqEi_vdjJGecm_iXkbqVoScViaU",
+						PublicKeyId: "public-key",
 					},
 					{
 						Signature: []byte("foo"),
-					},
-				},
-			},
-			wantErrs: true,
-		},
-		{
-			desc: "invalid public key format, want errors",
-			a: &gpb.AttestationOccurrence{
-				SerializedPayload: []byte("bar"),
-				Signatures: []*gpb.Signature{
-					{
-						Signature:   []byte("foo"),
-						PublicKeyId: "74FAF3B861BDA0870C7B6DEF607E48D2A663AEEA",
 					},
 				},
 			},
@@ -163,7 +146,7 @@ func TestValidateOccurrence(t *testing.T) {
 				Signatures: []*gpb.Signature{
 					{
 						Signature:   []byte("foo"),
-						PublicKeyId: "openpgp4fpr:74FAF3B861BDA0870C7B6DEF607E48D2A663AEEA",
+						PublicKeyId: "public-key",
 					},
 				},
 			},


### PR DESCRIPTION
Reverts grafeas/grafeas#432

This change breaks backwards compatibility and was based on inaccurate documentation.

1. The key IDs stored by Binauthz are unfortunately not in this format. To include this change, Binauthz would either need to backfill our database or edit key IDs on the fly as we retrieve them from the database. Other users of Grafeas will likely run into similar issues.

2. Patrick Lawson originally wrote this documentation, and I've confirmed with him that "public key ID MUST be RFC3986 conformant" is an error. It should read "public key ID SHOULD be
RFC3986 conformant". I'll update the documentation after this rollback is approved.