### PR TITLE
Make occurrence update tests less dependent on implementation details

### DIFF
--- a/go/v1/api/occurrence_test.go
+++ b/go/v1/api/occurrence_test.go
@@ -504,7 +504,8 @@ func TestUpdateOccurrenceErrors(t *testing.T) {
 
 	tests := []struct {
 		desc                        string
-		occName                     string
+		occName                     string // Ignored if existingOcc is supplied
+		existingOcc                 *gpb.Occurrence
 		occ                         *gpb.Occurrence
 		internalStorageErr, authErr bool
 		wantErrStatus               codes.Code
@@ -518,17 +519,29 @@ func TestUpdateOccurrenceErrors(t *testing.T) {
 		{
 			desc:          "nil occurrence",
 			occName:       "projects/consumer1/occurrences/1234-abcd-3456-wxyz",
+			existingOcc:   vulnzOcc(t, "consumer1", "projects/goog-vulnz/notes/CVE-UH-OH", "debian"),
 			occ:           nil,
 			wantErrStatus: codes.InvalidArgument,
 		},
 		{
 			desc:          "invalid note name",
 			occName:       "projects/consumer1/occurrences/1234-abcd-3456-wxyz",
+			existingOcc:   vulnzOcc(t, "consumer1", "projects/goog-vulnz/notes/CVE-UH-OH", "debian"),
 			occ:           vulnzOcc(t, "consumer1", "projects/foobar", "debian"),
 			wantErrStatus: codes.InvalidArgument,
 		},
 		{
 			desc:          "auth error",
+			existingOcc:   vulnzOcc(t, "consumer1", "projects/goog-vulnz/notes/CVE-UH-OH", "debian"),
+			occ:           vulnzOcc(t, "consumer1", "projects/goog-vulnz/notes/CVE-UH-OH", "debian"),
+			authErr:       true,
+			wantErrStatus: codes.PermissionDenied,
+		},
+		{
+			// This test ensures that users lacking the update permission get PermissionDenied
+			// rather than a NotFound error on a missing occurrence (ensuring that we do not
+			// leak the existence of an occurrence to unauthorized users).
+			desc:          "auth error with no existing occurrence",
 			occName:       "projects/consumer1/occurrences/1234-abcd-3456-wxyz",
 			occ:           vulnzOcc(t, "consumer1", "projects/goog-vulnz/notes/CVE-UH-OH", "debian"),
 			authErr:       true,
@@ -537,6 +550,7 @@ func TestUpdateOccurrenceErrors(t *testing.T) {
 		{
 			desc:               "internal storage error",
 			occName:            "projects/consumer1/occurrences/1234-abcd-3456-wxyz",
+			existingOcc:        vulnzOcc(t, "consumer1", "projects/goog-vulnz/notes/CVE-UH-OH", "debian"),
 			occ:                vulnzOcc(t, "consumer1", "projects/goog-vulnz/notes/CVE-UH-OH", "debian"),
 			internalStorageErr: true,
 			wantErrStatus:      codes.Internal,
@@ -559,8 +573,18 @@ func TestUpdateOccurrenceErrors(t *testing.T) {
 				EnforceValidation: true,
 			}
 
+			occName := tt.occName
+			if tt.existingOcc != nil {
+				// Create the occurrence to update.
+				createdOcc, err := s.CreateOccurrence(ctx, "consumer1", "", tt.existingOcc)
+				if err != nil {
+					t.Fatalf("Failed to create occurrence %+v", tt.existingOcc)
+				}
+				occName = createdOcc.Name
+			}
+
 			req := &gpb.UpdateOccurrenceRequest{
-				Name:       tt.occName,
+				Name:       occName,
 				Occurrence: tt.occ,
 			}
 			o := &gpb.Occurrence{}


### PR DESCRIPTION
The TestUpdateOccurrenceErrors currently rely on the fact that we check for an existing occurrence last.

For example, if writing to the the storage layer is erroring *and* there is no existing occurrence, the test is asserting that we return the storage error, which seems overspecified.

Update the tests so that there is an existing occurrence in the database for the test cases that are exercising other error paths.

The one exception is that it is important to return a permission error instead of a NotFound error if the user doesn't have the required permission (to avoid leaking the existence of a resource they don't have permission to see). I've added a test case to specifically validate that case. (The code is correct here, the test is just ensuring we are specifically testing that case.)