### PR TITLE
Fix permission checks in occurrence update function

### DIFF
--- a/go/v1/api/grafeas_test.go
+++ b/go/v1/api/grafeas_test.go
@@ -375,6 +375,35 @@ func (s *fakeStorage) ListNoteOccurrences(ctx context.Context, pID, nID, filter,
 	return foundOccs, "", nil
 }
 
+// projectPermission binds a permission to a project.
+type projectPermission struct {
+	permission iam.Permission
+	projectID  string
+}
+
+// allowListAuth implements grafeas.Auth, denying all access checks except those
+// in the specified allowList.
+type allowListAuth struct {
+	allowList []projectPermission
+}
+
+func (a *allowListAuth) CheckAccessAndProject(ctx context.Context, projectID string, entityID string, p iam.Permission) error {
+	for _, allowed := range a.allowList {
+		if allowed.permission == p && allowed.projectID == projectID {
+			return nil
+		}
+	}
+	return status.Errorf(codes.PermissionDenied, "permission %q denied for %q or %q", p, projectID, entityID)
+}
+
+func (a *allowListAuth) EndUserID(ctx context.Context) (string, error) {
+	return "42", nil
+}
+
+func (a *allowListAuth) PurgePolicy(ctx context.Context, projectID string, entityID string, r iam.Resource) error {
+	return nil
+}
+
 type fakeAuth struct {
 	// Whether auth calls return an error to exercise err code paths.
 	authErr, endUserIDErr, purgeErr bool

--- a/go/v1/api/occurrence_test.go
+++ b/go/v1/api/occurrence_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	gpb "github.com/grafeas/grafeas/proto/v1/grafeas_go_proto"
 	"golang.org/x/net/context"
+	fieldmaskpb "google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -587,6 +588,134 @@ func TestUpdateOccurrenceErrors(t *testing.T) {
 			t.Logf("%q: error: %v", tt.desc, err)
 			if status.Code(err) != tt.wantErrStatus {
 				t.Errorf("%q: got error status %v, want %v", tt.desc, status.Code(err), tt.wantErrStatus)
+			}
+		})
+	}
+}
+
+func TestUpdateOccurrencePermissions(t *testing.T) {
+	ctx := context.Background()
+	auth := allowListAuth{
+		allowList: []projectPermission{
+			{permission: NotesAttachOccurrence, projectID: "allowed-note"},
+			{permission: OccurrencesUpdate, projectID: "allowed-occurrence"},
+			{permission: OccurrencesGet, projectID: "read-only"},
+			{permission: OccurrencesList, projectID: "read-only"},
+			{permission: NotesGet, projectID: "read-only"},
+			{permission: NotesList, projectID: "read-only"},
+		},
+	}
+
+	tests := []struct {
+		desc        string
+		occProj     string
+		existingOcc *gpb.Occurrence
+		occ         *gpb.Occurrence
+		updateMask  *fieldmaskpb.FieldMask
+		wantStatus  codes.Code
+	}{
+		{
+			desc:        "allowed updates",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/allowed-note/notes/my-note"},
+			wantStatus:  codes.OK,
+		},
+		{
+			desc:        "no permission on occurrence",
+			occProj:     "forbidden-project",
+			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/allowed-note/notes/my-note"},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "no permission on note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/forbidden-project/notes/my-note"},
+			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/forbidden-project/notes/my-note"},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "read-only permission on occurrence",
+			occProj:     "read-only",
+			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/allowed-note/notes/my-note"},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "read-only permission on note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/forbidden-project/notes/my-note"},
+			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/read-only/notes/my-note"},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "no permission on existing note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/forbidden-project/notes/my-note"},
+			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/allowed-note/notes/my-note"},
+			wantStatus:  codes.OK, // TODO: Fix this; should return permission denied.
+		},
+		{
+			desc:        "no permission on new note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/forbidden-project/notes/my-note"},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "no permission on existing note with field mask",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/forbidden-project/notes/my-note"},
+			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/allowed-note/notes/my-note"},
+			updateMask:  &fieldmaskpb.FieldMask{Paths: []string{"resourceUri"}},
+			wantStatus:  codes.OK, // TODO: Fix this; should return permission denied.
+		},
+		{
+			desc:        "no permission on new note with field mask including note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/forbidden-project/notes/my-note"},
+			updateMask:  &fieldmaskpb.FieldMask{Paths: []string{"resourceUri", "noteName"}},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "no permission on new note with field mask excluding note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/forbidden-project/notes/my-note"},
+			updateMask:  &fieldmaskpb.FieldMask{Paths: []string{"resourceUri"}},
+			// In principle this could be allowed as the NoteName in the incoming occurrence is ignored, so
+			// there is no need to perform a permission check. But as this has been the behavior to date
+			// without any reported issues, it seems safer to leave this returning an error. If a use case for
+			// supporting this arises, it can be revisited.
+			wantStatus: codes.PermissionDenied,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			s := newFakeStorage()
+			g := &API{
+				Storage:           s,
+				Auth:              &auth,
+				EnforceValidation: true,
+			}
+
+			// Create the occurrence to update.
+			createdOcc, err := s.CreateOccurrence(ctx, tt.occProj, "", tt.existingOcc)
+			if err != nil {
+				t.Fatalf("Failed to create occurrence %+v", tt.existingOcc)
+			}
+
+			req := &gpb.UpdateOccurrenceRequest{
+				Name:       createdOcc.Name,
+				Occurrence: tt.occ,
+				UpdateMask: tt.updateMask,
+			}
+			_, err = g.UpdateOccurrence(ctx, req)
+			if status.Code(err) != tt.wantStatus {
+				t.Fatalf("UpdateOccurrence: got status %v, want %v", status.Code(err), tt.wantStatus)
 			}
 		})
 	}

--- a/go/v1/api/occurrence_test.go
+++ b/go/v1/api/occurrence_test.go
@@ -654,7 +654,7 @@ func TestUpdateOccurrencePermissions(t *testing.T) {
 			occProj:     "allowed-occurrence",
 			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/forbidden-project/notes/my-note"},
 			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/allowed-note/notes/my-note"},
-			wantStatus:  codes.OK, // TODO: Fix this; should return permission denied.
+			wantStatus:  codes.PermissionDenied,
 		},
 		{
 			desc:        "no permission on new note",
@@ -669,7 +669,7 @@ func TestUpdateOccurrencePermissions(t *testing.T) {
 			existingOcc: &gpb.Occurrence{ResourceUri: "old-uri", NoteName: "projects/forbidden-project/notes/my-note"},
 			occ:         &gpb.Occurrence{ResourceUri: "new-uri", NoteName: "projects/allowed-note/notes/my-note"},
 			updateMask:  &fieldmaskpb.FieldMask{Paths: []string{"resourceUri"}},
-			wantStatus:  codes.OK, // TODO: Fix this; should return permission denied.
+			wantStatus:  codes.PermissionDenied,
 		},
 		{
 			desc:        "no permission on new note with field mask including note",

--- a/go/v1beta1/api/occurrence.go
+++ b/go/v1beta1/api/occurrence.go
@@ -209,12 +209,32 @@ func (g *API) UpdateOccurrence(ctx context.Context, req *gpb.UpdateOccurrenceReq
 	if err := g.Auth.CheckAccessAndProject(ctx, pID, oID, OccurrencesUpdate); err != nil {
 		return nil, err
 	}
-	notePID, nID, err := name.ParseNote(req.Occurrence.NoteName)
+
+	// The user must have attach permissions on the note currently associated with the occurrence.
+	existing, err := g.Storage.GetOccurrence(ctx, pID, oID)
 	if err != nil {
 		return nil, err
 	}
-	if err := g.Auth.CheckAccessAndProject(ctx, notePID, nID, NotesAttachOccurrence); err != nil {
-		return nil, err
+	if existing.NoteName != "" {
+		notePID, nID, err := name.ParseNote(existing.NoteName)
+		if err != nil {
+			return nil, err
+		}
+		if err := g.Auth.CheckAccessAndProject(ctx, notePID, nID, NotesAttachOccurrence); err != nil {
+			return nil, err
+		}
+	}
+
+	// If the user is modifying the noteName, they must also have attach permissions
+	// on the newly-associated note.
+	if req.Occurrence.NoteName != existing.NoteName {
+		notePID, nID, err := name.ParseNote(req.Occurrence.NoteName)
+		if err != nil {
+			return nil, err
+		}
+		if err := g.Auth.CheckAccessAndProject(ctx, notePID, nID, NotesAttachOccurrence); err != nil {
+			return nil, err
+		}
 	}
 
 	o, err := g.Storage.UpdateOccurrence(ctx, pID, oID, req.Occurrence, req.UpdateMask)

--- a/go/v1beta1/api/occurrence_test.go
+++ b/go/v1beta1/api/occurrence_test.go
@@ -25,6 +25,7 @@ import (
 	provpb "github.com/grafeas/grafeas/proto/v1beta1/provenance_go_proto"
 	vpb "github.com/grafeas/grafeas/proto/v1beta1/vulnerability_go_proto"
 	"golang.org/x/net/context"
+	fieldmaskpb "google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -616,6 +617,136 @@ func TestUpdateOccurrenceErrors(t *testing.T) {
 			t.Logf("%q: error: %v", tt.desc, err)
 			if status.Code(err) != tt.wantErrStatus {
 				t.Errorf("%q: got error status %v, want %v", tt.desc, status.Code(err), tt.wantErrStatus)
+			}
+		})
+	}
+}
+
+func TestUpdateOccurrencePermissions(t *testing.T) {
+	ctx := context.Background()
+	auth := allowListAuth{
+		allowList: []projectPermission{
+			{permission: NotesAttachOccurrence, projectID: "allowed-note"},
+			{permission: OccurrencesUpdate, projectID: "allowed-occurrence"},
+			{permission: OccurrencesGet, projectID: "read-only"},
+			{permission: OccurrencesList, projectID: "read-only"},
+			{permission: NotesGet, projectID: "read-only"},
+			{permission: NotesList, projectID: "read-only"},
+		},
+	}
+
+	tests := []struct {
+		desc        string
+		occProj     string
+		existingOcc *gpb.Occurrence
+		occ         *gpb.Occurrence
+		updateMask  *fieldmaskpb.FieldMask
+		wantStatus  codes.Code
+	}{
+		{
+			desc:        "allowed updates",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
+			wantStatus:  codes.OK,
+		},
+		{
+			desc:        "no permission on occurrence",
+			occProj:     "forbidden-project",
+			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "no permission on note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/forbidden-project/notes/my-note"},
+			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/forbidden-project/notes/my-note"},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "read-only permission on occurrence",
+			occProj:     "read-only",
+			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "read-only permission on note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/forbidden-project/notes/my-note"},
+			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/read-only/notes/my-note"},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "no permission on existing note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/forbidden-project/notes/my-note"},
+			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
+			wantStatus:  codes.OK, // TODO: Fix this; should return permission denied.
+		},
+		{
+			desc:        "no permission on new note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/forbidden-project/notes/my-note"},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "no permission on existing note with field mask",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/forbidden-project/notes/my-note"},
+			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
+			updateMask:  &fieldmaskpb.FieldMask{Paths: []string{"resourceUri"}},
+			wantStatus:  codes.OK, // TODO: Fix this; should return permission denied.
+		},
+		{
+			desc:        "no permission on new note with field mask including note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/forbidden-project/notes/my-note"},
+			updateMask:  &fieldmaskpb.FieldMask{Paths: []string{"resourceUri", "noteName"}},
+			wantStatus:  codes.PermissionDenied,
+		},
+		{
+			desc:        "no permission on new note with field mask excluding note",
+			occProj:     "allowed-occurrence",
+			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
+			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/forbidden-project/notes/my-note"},
+			updateMask:  &fieldmaskpb.FieldMask{Paths: []string{"resourceUri"}},
+			// In principle this could be allowed as the NoteName in the incoming occurrence is ignored, so
+			// there is no need to perform a permission check. But as this has been the behavior to date
+			// without any reported issues, it seems safer to leave this returning an error. If a use case for
+			// supporting this arises, it can be revisited.
+			wantStatus: codes.PermissionDenied,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			s := newFakeStorage()
+			g := &API{
+				Storage:           s,
+				Auth:              &auth,
+				Filter:            &fakeFilter{},
+				Logger:            &fakeLogger{},
+				EnforceValidation: true,
+			}
+
+			// Create the occurrence to update.
+			createdOcc, err := s.CreateOccurrence(ctx, tt.occProj, "", tt.existingOcc)
+			if err != nil {
+				t.Fatalf("Failed to create occurrence %+v", tt.existingOcc)
+			}
+
+			req := &gpb.UpdateOccurrenceRequest{
+				Name:       createdOcc.Name,
+				Occurrence: tt.occ,
+				UpdateMask: tt.updateMask,
+			}
+			_, err = g.UpdateOccurrence(ctx, req)
+			if status.Code(err) != tt.wantStatus {
+				t.Fatalf("UpdateOccurrence: got status %v, want %v", status.Code(err), tt.wantStatus)
 			}
 		})
 	}

--- a/go/v1beta1/api/occurrence_test.go
+++ b/go/v1beta1/api/occurrence_test.go
@@ -683,7 +683,7 @@ func TestUpdateOccurrencePermissions(t *testing.T) {
 			occProj:     "allowed-occurrence",
 			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/forbidden-project/notes/my-note"},
 			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
-			wantStatus:  codes.OK, // TODO: Fix this; should return permission denied.
+			wantStatus:  codes.PermissionDenied,
 		},
 		{
 			desc:        "no permission on new note",
@@ -698,7 +698,7 @@ func TestUpdateOccurrencePermissions(t *testing.T) {
 			existingOcc: &gpb.Occurrence{Resource: &gpb.Resource{Uri: "old-uri"}, NoteName: "projects/forbidden-project/notes/my-note"},
 			occ:         &gpb.Occurrence{Resource: &gpb.Resource{Uri: "new-uri"}, NoteName: "projects/allowed-note/notes/my-note"},
 			updateMask:  &fieldmaskpb.FieldMask{Paths: []string{"resourceUri"}},
-			wantStatus:  codes.OK, // TODO: Fix this; should return permission denied.
+			wantStatus:  codes.PermissionDenied,
 		},
 		{
 			desc:        "no permission on new note with field mask including note",


### PR DESCRIPTION
* Add tests on permission checking

  Add some tests to validate the permission checks on UpdateOccurrence operations. To support the tests, add a allowListAuth test implementation of Auth that just stores a list of allowed project/permission pairs.

  Two of the tests are documenting incorrect behavior that is fixed in a later commit. Namely:
  (1) Updating the NoteName should require NotesAttachOccurrence on the old NoteName (as this is effectively a detach operation).
  (2) When excluding the NoteName from the update using an UpdateMask, the permission check should be performed against the existing NoteName, not whatever was passed in (and which will be ignored).

* Fix permission checks in occurrence update function

  This commit fixes the permission checks in UpdateOccurrence and updates the tests from the last commit to demonstrate the change.

  In particular, we now check the NotesAttachOccurrence on the occurrence's existing NoteName before allowing updates. We continue to check the NotesAttachOccurrence on the updated NoteName (if it is different from the existing NoteName whose permission has already been checked). This means that updating an occurrence from one note to another requires NotesAttachOccurrence on both notes.