### PR TITLE
Update to curl flags with certificate

### DIFF
--- a/docs/running_grafeas.md
+++ b/docs/running_grafeas.md
@@ -138,7 +138,7 @@ openssl pkcs12 -in server.p12 -out server.pem -clcerts
 Now, `curl` the endpoint:
 
 ```bash
-curl -k --cert server.pem https://localhost:8080/v1beta1/projects
+curl -k --key server.key --cacert ca.pem --cert server.pem https://localhost:8080/v1beta1/projects
 ```
 
 ### gRPC with a go client


### PR DESCRIPTION
The instructions for using the curl command with the certificate didn't work for me.  I got the error message: 

`curl: (58) unable to set private key file: 'server.pem' type PEM`

When I added these additional flags, it worked fine.