### PR TITLE
Add the vendor field to Vulnerability.Detail

### DIFF
--- a/proto/v1beta1/vulnerability.proto
+++ b/proto/v1beta1/vulnerability.proto
@@ -98,6 +98,9 @@ message Vulnerability {
 
     // The source from which the information in this Detail was obtained.
     string source = 11;
+
+    // The name of the vendor of the product.
+    string vendor = 12;
   }
 
   // The full description of the CVSSv3.


### PR DESCRIPTION
Add the vendor field to Vulnerability.Detail, which is necessary to differentiate between products of the same name in the NVD 1.1 feed.