### PR TITLE
Fixed issue with boolean evaluation on command line value switch truthy

### DIFF
--- a/grafeas-charts/templates/secrets.yaml
+++ b/grafeas-charts/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.secret.enabled }}
+{{- if eq .Values.secret.enabled true }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
When trying to run helm install or helm upgrade with the  `--set secret.enabled=true` switch no secrets were being created. I used the same format for evaluation of truthy values as used in the configmap template and it works.