### PR TITLE
add java_outer_classname to intoto to avoid java client generation failures

### DIFF
--- a/proto/v1/intoto_provenance.proto
+++ b/proto/v1/intoto_provenance.proto
@@ -20,6 +20,7 @@ option go_package = "github.com/grafeas/grafeas/proto/v1/grafeas_go_proto";
 option java_multiple_files = true;
 option java_package = "io.grafeas.v1";
 option objc_class_prefix = "GRA";
+option java_outer_classname = "InTotoProvenanceProto";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/any.proto";


### PR DESCRIPTION
Java clients that are generated from these protos fail to build due to the mismatch between the name of the proto message and the name of the file. Specifically, the filename will be converted to `IntotoProvenance` while the actual message is `InTotoProvenance`. This is causing downstream issues: https://github.com/googleapis/java-grafeas/pull/410

This PR resolves this issue by setting the Java name explicitly.