### PR TITLE
Updates grpc-gateway@v2.7.3

### DIFF
--- a/cel/syntax.pb.go
+++ b/cel/syntax.pb.go
@@ -514,7 +514,7 @@ type SourceInfo struct {
 	//
 	// The line number of a given position is the index `i` where for a given
 	// `id` the `line_offsets[i] < id_positions[id] < line_offsets[i+1]`. The
-	// column may be derived from `id_positions[id] - line_offsets[i]`.
+	// column may be derivd from `id_positions[id] - line_offsets[i]`.
 	LineOffsets []int32 `protobuf:"varint,3,rep,packed,name=line_offsets,json=lineOffsets,proto3" json:"line_offsets,omitempty"`
 	// A map from the parse node id (e.g. `Expr.id`) to the character offset
 	// within source.
@@ -587,7 +587,7 @@ type SourcePosition struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The source location name (e.g. file name).
+	// The soucre location name (e.g. file name).
 	Location string `protobuf:"bytes,1,opt,name=location,proto3" json:"location,omitempty"`
 	// The character offset.
 	Offset int32 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`

--- a/cel/syntax.pb.go
+++ b/cel/syntax.pb.go
@@ -514,7 +514,7 @@ type SourceInfo struct {
 	//
 	// The line number of a given position is the index `i` where for a given
 	// `id` the `line_offsets[i] < id_positions[id] < line_offsets[i+1]`. The
-	// column may be derivd from `id_positions[id] - line_offsets[i]`.
+	// column may be derived from `id_positions[id] - line_offsets[i]`.
 	LineOffsets []int32 `protobuf:"varint,3,rep,packed,name=line_offsets,json=lineOffsets,proto3" json:"line_offsets,omitempty"`
 	// A map from the parse node id (e.g. `Expr.id`) to the character offset
 	// within source.
@@ -587,7 +587,7 @@ type SourcePosition struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The soucre location name (e.g. file name).
+	// The source location name (e.g. file name).
 	Location string `protobuf:"bytes,1,opt,name=location,proto3" json:"location,omitempty"`
 	// The character offset.
 	Offset int32 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -8,17 +8,16 @@ require (
 	github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292
 	github.com/fernet/fernet-go v0.0.0-20191111064656-eff2850e6001
 	github.com/golang/protobuf v1.5.2
-	github.com/google/go-cmp v0.5.6
+	github.com/google/go-cmp v0.5.7
 	github.com/google/logger v1.1.0
 	github.com/google/uuid v1.1.2
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3
 	github.com/lib/pq v1.8.0
 	github.com/rs/cors v1.7.0
 	github.com/spf13/viper v1.7.1
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
-	google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1
-	google.golang.org/grpc v1.42.0
+	google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5
+	google.golang.org/grpc v1.43.0
 	google.golang.org/grpc/examples v0.0.0-20201112215255-90f1b3ee835b // indirect
 	google.golang.org/protobuf v1.27.1
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/logger v1.1.0 h1:saB74Etb4EAJNH3z74CVbCKk75hld/8T0CsXKetWCwM=
 github.com/google/logger v1.1.0/go.mod h1:w7O8nrRr0xufejBlQMI83MXqRusvREoJdaAxV+CoAB4=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -166,8 +166,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QGdLI4y34qQGjGWO0=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3 h1:I8MsauTJQXZ8df8qJvEln0kYNc3bSapuaSsEsnFdEFU=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3/go.mod h1:lZdb/YAJUSj9OqrCHs2ihjtoO3+xK3G53wTYXFWRGDo=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -523,8 +523,8 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1 h1:b9mVrqYfq3P4bCdaLg1qtBnPzUYgglsIdjZkL/fQVOE=
-google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5 h1:zzNejm+EgrbLfDZ6lu9Uud2IVvHySPl8vQzf04laR5Q=
+google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -540,8 +540,8 @@ google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
-google.golang.org/grpc v1.42.0 h1:XT2/MFpuPFsEX2fWh3YQtHkZ+WYZFQRfaUgLZYj/p6A=
-google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
+google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/examples v0.0.0-20201112215255-90f1b3ee835b h1:NuxyvVZoDfHZwYW9LD4GJiF5/nhiSyP4/InTrvw9Ibk=
 google.golang.org/grpc/examples v0.0.0-20201112215255-90f1b3ee835b/go.mod h1:IBqQ7wSUJ2Ep09a8rMWFsg4fmI2r38zwsq8a0GgxXpM=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
@@ -585,3 +585,4 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/proto/v1alpha1/grafeas.proto
+++ b/proto/v1alpha1/grafeas.proto
@@ -1340,26 +1340,6 @@ service Grafeas {
     };
   }
 
-  // Creates a new `Operation`.
-  rpc CreateOperation(CreateOperationRequest)
-  returns (google.longrunning.Operation) {
-    option (google.api.http) = {
-      post: "/v1alpha1/{parent=projects/*}/operations"
-      body: "*"
-    };
-  };
-
-  // Updates an existing operation returns an error if operation
-  //  does not exist. The only valid operations are to update mark the done bit
-  // change the result.
-  rpc UpdateOperation(UpdateOperationRequest)
-  returns (google.longrunning.Operation) {
-    option (google.api.http) = {
-      patch: "/v1alpha1/{name=projects/*/operations/*}"
-      body: "*"
-    };
-  };
-
   // Returns the requested `Note`.
   rpc GetNote(GetNoteRequest) returns (Note) {
     option (google.api.http) = {
@@ -1406,6 +1386,26 @@ service Grafeas {
       get: "/v1alpha1/{name=projects/*/notes/*}/occurrences"
     };
   }
+
+  // Creates a new `Operation`.
+  rpc CreateOperation(CreateOperationRequest)
+      returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v1alpha1/{parent=projects/*}/operations"
+      body: "*"
+    };
+  };
+
+  // Updates an existing operation returns an error if operation
+  //  does not exist. The only valid operations are to update mark the done bit
+  // change the result.
+  rpc UpdateOperation(UpdateOperationRequest)
+      returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      patch: "/v1alpha1/{name=projects/*/operations/*}"
+      body: "*"
+    };
+  };
 }
 
 // [GrafeasProjects](grafeas.io) API.

--- a/proto/v1alpha1/swagger/grafeas.swagger.json
+++ b/proto/v1alpha1/swagger/grafeas.swagger.json
@@ -98,7 +98,7 @@
         ]
       }
     },
-    "/v1alpha1/{name=projects/*/notes/*}": {
+    "/v1alpha1/{name_1}": {
       "get": {
         "summary": "Returns the requested `Note`.",
         "operationId": "Grafeas_GetNote",
@@ -118,11 +118,12 @@
         },
         "parameters": [
           {
-            "name": "name",
+            "name": "name_1",
             "description": "The name of the note in the form of\n\"providers/{provider_id}/notes/{NOTE_ID}\"",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/notes/[^/]+"
           }
         ],
         "tags": [
@@ -148,11 +149,12 @@
         },
         "parameters": [
           {
-            "name": "name",
+            "name": "name_1",
             "description": "The name of the note in the form of\n\"providers/{provider_id}/notes/{NOTE_ID}\"",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/notes/[^/]+"
           }
         ],
         "tags": [
@@ -178,11 +180,12 @@
         },
         "parameters": [
           {
-            "name": "name",
+            "name": "name_1",
             "description": "The name of the note.\nShould be of the form \"projects/{provider_id}/notes/{note_id}\".",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/notes/[^/]+"
           },
           {
             "name": "body",
@@ -206,15 +209,15 @@
         ]
       }
     },
-    "/v1alpha1/{name=projects/*/notes/*}/occurrences": {
+    "/v1alpha1/{name_2}": {
       "get": {
-        "summary": "Lists `Occurrences` referencing the specified `Note`. Use this method to\nget all occurrences referencing your `Note` across all your customer\nprojects.",
-        "operationId": "Grafeas_ListNoteOccurrences",
+        "summary": "Gets the specified project.",
+        "operationId": "GrafeasProjects_GetProject",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiListNoteOccurrencesResponse"
+              "$ref": "#/definitions/apiProject"
             }
           },
           "default": {
@@ -226,33 +229,89 @@
         },
         "parameters": [
           {
-            "name": "name",
-            "description": "The name field will contain the note name for example:\n  \"provider/{provider_id}/notes/{note_id}\"",
+            "name": "name_2",
+            "description": "The name of the project in the form of `projects/{PROJECT_ID}`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
+          }
+        ],
+        "tags": [
+          "GrafeasProjects"
+        ]
+      },
+      "delete": {
+        "summary": "Deletes the specified project.",
+        "operationId": "GrafeasProjects_DeleteProject",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name_2",
+            "description": "The name of the project in the form of `projects/{PROJECT_ID}`.",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "projects/[^/]+"
+          }
+        ],
+        "tags": [
+          "GrafeasProjects"
+        ]
+      },
+      "patch": {
+        "summary": "Updates an existing operation returns an error if operation\n does not exist. The only valid operations are to update mark the done bit\nchange the result.",
+        "operationId": "Grafeas_UpdateOperation",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/googlelongrunningOperation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name_2",
+            "description": "The name of the Operation.\nShould be of the form \"projects/{provider_id}/operations/{operation_id}\".",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "projects/[^/]+/operations/[^/]+"
           },
           {
-            "name": "filter",
-            "description": "The filter expression.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "pageSize",
-            "description": "Number of notes to return in the list.",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int32"
-          },
-          {
-            "name": "pageToken",
-            "description": "Token to provide to skip to a particular spot in the list.",
-            "in": "query",
-            "required": false,
-            "type": "string"
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "operation": {
+                  "$ref": "#/definitions/googlelongrunningOperation",
+                  "description": "The operation to create."
+                }
+              },
+              "title": "Request for updating an existing operation"
+            }
           }
         ],
         "tags": [
@@ -260,7 +319,7 @@
         ]
       }
     },
-    "/v1alpha1/{name=projects/*/occurrences/*}": {
+    "/v1alpha1/{name}": {
       "get": {
         "summary": "Returns the requested `Occurrence`.",
         "operationId": "Grafeas_GetOccurrence",
@@ -284,7 +343,8 @@
             "description": "The name of the occurrence of the form\n\"projects/{project_id}/occurrences/{OCCURRENCE_ID}\"",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/occurrences/[^/]+"
           }
         ],
         "tags": [
@@ -314,7 +374,8 @@
             "description": "The name of the occurrence in the form of\n\"projects/{project_id}/occurrences/{OCCURRENCE_ID}\"",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/occurrences/[^/]+"
           }
         ],
         "tags": [
@@ -344,7 +405,8 @@
             "description": "The name of the occurrence.\nShould be of the form \"projects/{project_id}/occurrences/{OCCURRENCE_ID}\".",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/occurrences/[^/]+"
           },
           {
             "name": "body",
@@ -368,7 +430,7 @@
         ]
       }
     },
-    "/v1alpha1/{name=projects/*/occurrences/*}/notes": {
+    "/v1alpha1/{name}/notes": {
       "get": {
         "summary": "Gets the `Note` attached to the given `Occurrence`.",
         "operationId": "Grafeas_GetOccurrenceNote",
@@ -392,7 +454,8 @@
             "description": "The name of the occurrence in the form\n\"projects/{project_id}/occurrences/{OCCURRENCE_ID}\"",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/occurrences/[^/]+"
           }
         ],
         "tags": [
@@ -400,62 +463,15 @@
         ]
       }
     },
-    "/v1alpha1/{name=projects/*/operations/*}": {
-      "patch": {
-        "summary": "Updates an existing operation returns an error if operation\n does not exist. The only valid operations are to update mark the done bit\nchange the result.",
-        "operationId": "Grafeas_UpdateOperation",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/googlelongrunningOperation"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "name",
-            "description": "The name of the Operation.\nShould be of the form \"projects/{provider_id}/operations/{operation_id}\".",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "object",
-              "properties": {
-                "operation": {
-                  "$ref": "#/definitions/googlelongrunningOperation",
-                  "description": "The operation to create."
-                }
-              },
-              "title": "Request for updating an existing operation"
-            }
-          }
-        ],
-        "tags": [
-          "Grafeas"
-        ]
-      }
-    },
-    "/v1alpha1/{name=projects/*}": {
+    "/v1alpha1/{name}/occurrences": {
       "get": {
-        "summary": "Gets the specified project.",
-        "operationId": "GrafeasProjects_GetProject",
+        "summary": "Lists `Occurrences` referencing the specified `Note`. Use this method to\nget all occurrences referencing your `Note` across all your customer\nprojects.",
+        "operationId": "Grafeas_ListNoteOccurrences",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiProject"
+              "$ref": "#/definitions/apiListNoteOccurrencesResponse"
             }
           },
           "default": {
@@ -468,48 +484,41 @@
         "parameters": [
           {
             "name": "name",
-            "description": "The name of the project in the form of `projects/{PROJECT_ID}`.",
+            "description": "The name field will contain the note name for example:\n  \"provider/{provider_id}/notes/{note_id}\"",
             "in": "path",
             "required": true,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "GrafeasProjects"
-        ]
-      },
-      "delete": {
-        "summary": "Deletes the specified project.",
-        "operationId": "GrafeasProjects_DeleteProject",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "properties": {}
-            }
+            "type": "string",
+            "pattern": "projects/[^/]+/notes/[^/]+"
           },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
           {
-            "name": "name",
-            "description": "The name of the project in the form of `projects/{PROJECT_ID}`.",
-            "in": "path",
-            "required": true,
+            "name": "filter",
+            "description": "The filter expression.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "description": "Number of notes to return in the list.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "description": "Token to provide to skip to a particular spot in the list.",
+            "in": "query",
+            "required": false,
             "type": "string"
           }
         ],
         "tags": [
-          "GrafeasProjects"
+          "Grafeas"
         ]
       }
     },
-    "/v1alpha1/{parent=projects/*}/notes": {
+    "/v1alpha1/{parent}/notes": {
       "get": {
         "summary": "Lists all `Notes` for a given project.",
         "operationId": "Grafeas_ListNotes",
@@ -533,7 +542,8 @@
             "description": "This field contains the project ID for example: \"projects/{project_id}\".",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "filter",
@@ -585,7 +595,8 @@
             "description": "This field contains the project Id for example:\n\"project/{project_id}",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "body",
@@ -609,7 +620,7 @@
         ]
       }
     },
-    "/v1alpha1/{parent=projects/*}/occurrences": {
+    "/v1alpha1/{parent}/occurrences": {
       "get": {
         "summary": "Lists active `Occurrences` for a given project matching the filters.",
         "operationId": "Grafeas_ListOccurrences",
@@ -633,7 +644,8 @@
             "description": "This contains the project Id for example: projects/{project_id}.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "filter",
@@ -685,7 +697,8 @@
             "description": "This field contains the project Id for example: \"projects/{project_id}\"",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "body",
@@ -702,7 +715,7 @@
         ]
       }
     },
-    "/v1alpha1/{parent=projects/*}/operations": {
+    "/v1alpha1/{parent}/operations": {
       "post": {
         "summary": "Creates a new `Operation`.",
         "operationId": "Grafeas_CreateOperation",
@@ -726,7 +739,8 @@
             "description": "The projectId that this operation should be created under.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "body",

--- a/proto/v1beta1/grafeas_go_proto/grafeas.pb.gw.go
+++ b/proto/v1beta1/grafeas_go_proto/grafeas.pb.gw.go
@@ -1442,7 +1442,7 @@ func RegisterGrafeasV1Beta1HandlerFromEndpoint(ctx context.Context, mux *runtime
 
 // RegisterGrafeasV1Beta1Handler registers the http handlers for service GrafeasV1Beta1 to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterGrafeasV1Beta1Handler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterGrafeasV1Beta1Handler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterGrafeasV1Beta1HandlerClient(ctx, mux, NewGrafeasV1Beta1Client(conn))
 }
 

--- a/proto/v1beta1/project_go_proto/project.pb.gw.go
+++ b/proto/v1beta1/project_go_proto/project.pb.gw.go
@@ -333,7 +333,7 @@ func RegisterProjectsHandlerFromEndpoint(ctx context.Context, mux *runtime.Serve
 
 // RegisterProjectsHandler registers the http handlers for service Projects to "mux".
 // The handlers forward requests to the grpc endpoint over "conn".
-func RegisterProjectsHandler(ctx context.Context, mux *runtime.ServeMux, conn grpc.ClientConnInterface) error {
+func RegisterProjectsHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
 	return RegisterProjectsHandlerClient(ctx, mux, NewProjectsClient(conn))
 }
 

--- a/proto/v1beta1/swagger/grafeas.swagger.json
+++ b/proto/v1beta1/swagger/grafeas.swagger.json
@@ -16,7 +16,7 @@
     "application/json"
   ],
   "paths": {
-    "/v1beta1/{name=projects/*/notes/*}": {
+    "/v1beta1/{name_1}": {
       "get": {
         "summary": "Gets the specified note.",
         "operationId": "GrafeasV1Beta1_GetNote",
@@ -36,11 +36,12 @@
         },
         "parameters": [
           {
-            "name": "name",
+            "name": "name_1",
             "description": "The name of the note in the form of\n`projects/[PROVIDER_ID]/notes/[NOTE_ID]`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/notes/[^/]+"
           }
         ],
         "tags": [
@@ -66,11 +67,12 @@
         },
         "parameters": [
           {
-            "name": "name",
+            "name": "name_1",
             "description": "The name of the note in the form of\n`projects/[PROVIDER_ID]/notes/[NOTE_ID]`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/notes/[^/]+"
           }
         ],
         "tags": [
@@ -96,11 +98,12 @@
         },
         "parameters": [
           {
-            "name": "name",
+            "name": "name_1",
             "description": "The name of the note in the form of\n`projects/[PROVIDER_ID]/notes/[NOTE_ID]`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/notes/[^/]+"
           },
           {
             "name": "body",
@@ -124,61 +127,7 @@
         ]
       }
     },
-    "/v1beta1/{name=projects/*/notes/*}/occurrences": {
-      "get": {
-        "summary": "Lists occurrences referencing the specified note. Provider projects can use\nthis method to get all occurrences across consumer projects referencing the\nspecified note.",
-        "operationId": "GrafeasV1Beta1_ListNoteOccurrences",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1beta1ListNoteOccurrencesResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "name",
-            "description": "The name of the note to list occurrences for in the form of\n`projects/[PROVIDER_ID]/notes/[NOTE_ID]`.",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "filter",
-            "description": "The filter expression.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "pageSize",
-            "description": "Number of occurrences to return in the list.",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int32"
-          },
-          {
-            "name": "pageToken",
-            "description": "Token to provide to skip to a particular spot in the list.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "GrafeasV1Beta1"
-        ]
-      }
-    },
-    "/v1beta1/{name=projects/*/occurrences/*}": {
+    "/v1beta1/{name}": {
       "get": {
         "summary": "Gets the specified occurrence.",
         "operationId": "GrafeasV1Beta1_GetOccurrence",
@@ -202,7 +151,8 @@
             "description": "The name of the occurrence in the form of\n`projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/occurrences/[^/]+"
           }
         ],
         "tags": [
@@ -232,7 +182,8 @@
             "description": "The name of the occurrence in the form of\n`projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/occurrences/[^/]+"
           }
         ],
         "tags": [
@@ -262,7 +213,8 @@
             "description": "The name of the occurrence in the form of\n`projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+/occurrences/[^/]+"
           },
           {
             "name": "body",
@@ -286,7 +238,7 @@
         ]
       }
     },
-    "/v1beta1/{name=projects/*/occurrences/*}/notes": {
+    "/v1beta1/{name}/notes": {
       "get": {
         "summary": "Gets the note attached to the specified occurrence. Consumer projects can\nuse this method to get a note that belongs to a provider project.",
         "operationId": "GrafeasV1Beta1_GetOccurrenceNote",
@@ -310,6 +262,62 @@
             "description": "The name of the occurrence in the form of\n`projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.",
             "in": "path",
             "required": true,
+            "type": "string",
+            "pattern": "projects/[^/]+/occurrences/[^/]+"
+          }
+        ],
+        "tags": [
+          "GrafeasV1Beta1"
+        ]
+      }
+    },
+    "/v1beta1/{name}/occurrences": {
+      "get": {
+        "summary": "Lists occurrences referencing the specified note. Provider projects can use\nthis method to get all occurrences across consumer projects referencing the\nspecified note.",
+        "operationId": "GrafeasV1Beta1_ListNoteOccurrences",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1ListNoteOccurrencesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "description": "The name of the note to list occurrences for in the form of\n`projects/[PROVIDER_ID]/notes/[NOTE_ID]`.",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "projects/[^/]+/notes/[^/]+"
+          },
+          {
+            "name": "filter",
+            "description": "The filter expression.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "description": "Number of occurrences to return in the list.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "description": "Token to provide to skip to a particular spot in the list.",
+            "in": "query",
+            "required": false,
             "type": "string"
           }
         ],
@@ -318,7 +326,7 @@
         ]
       }
     },
-    "/v1beta1/{parent=projects/*}/notes": {
+    "/v1beta1/{parent}/notes": {
       "get": {
         "summary": "Lists notes for the specified project.",
         "operationId": "GrafeasV1Beta1_ListNotes",
@@ -342,7 +350,8 @@
             "description": "The name of the project to list notes for in the form of\n`projects/[PROJECT_ID]`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "filter",
@@ -394,7 +403,8 @@
             "description": "The name of the project in the form of `projects/[PROJECT_ID]`, under which\nthe note is to be created.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "body",
@@ -418,7 +428,7 @@
         ]
       }
     },
-    "/v1beta1/{parent=projects/*}/notes:batchCreate": {
+    "/v1beta1/{parent}/notes:batchCreate": {
       "post": {
         "summary": "Creates new notes in batch.",
         "operationId": "GrafeasV1Beta1_BatchCreateNotes",
@@ -442,7 +452,8 @@
             "description": "The name of the project in the form of `projects/[PROJECT_ID]`, under which\nthe notes are to be created.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "body",
@@ -474,7 +485,7 @@
         ]
       }
     },
-    "/v1beta1/{parent=projects/*}/occurrences": {
+    "/v1beta1/{parent}/occurrences": {
       "get": {
         "summary": "Lists occurrences for the specified project.",
         "operationId": "GrafeasV1Beta1_ListOccurrences",
@@ -498,7 +509,8 @@
             "description": "The name of the project to list occurrences for in the form of\n`projects/[PROJECT_ID]`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "filter",
@@ -550,7 +562,8 @@
             "description": "The name of the project in the form of `projects/[PROJECT_ID]`, under which\nthe occurrence is to be created.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "body",
@@ -567,7 +580,7 @@
         ]
       }
     },
-    "/v1beta1/{parent=projects/*}/occurrences:batchCreate": {
+    "/v1beta1/{parent}/occurrences:batchCreate": {
       "post": {
         "summary": "Creates new occurrences in batch.",
         "operationId": "GrafeasV1Beta1_BatchCreateOccurrences",
@@ -591,7 +604,8 @@
             "description": "The name of the project in the form of `projects/[PROJECT_ID]`, under which\nthe occurrences are to be created.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "body",
@@ -623,7 +637,7 @@
         ]
       }
     },
-    "/v1beta1/{parent=projects/*}/occurrences:vulnerabilitySummary": {
+    "/v1beta1/{parent}/occurrences:vulnerabilitySummary": {
       "get": {
         "summary": "Gets a summary of the number and severity of occurrences.",
         "operationId": "GrafeasV1Beta1_GetVulnerabilityOccurrencesSummary",
@@ -647,7 +661,8 @@
             "description": "The name of the project to get a vulnerability summary for in the form of\n`projects/[PROJECT_ID]`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           },
           {
             "name": "filter",

--- a/proto/v1beta1/swagger/project.swagger.json
+++ b/proto/v1beta1/swagger/project.swagger.json
@@ -95,7 +95,7 @@
         ]
       }
     },
-    "/v1beta1/{name=projects/*}": {
+    "/v1beta1/{name}": {
       "get": {
         "summary": "Gets the specified project.",
         "operationId": "Projects_GetProject",
@@ -119,7 +119,8 @@
             "description": "The name of the project in the form of `projects/{PROJECT_ID}`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           }
         ],
         "tags": [
@@ -149,7 +150,8 @@
             "description": "The name of the project in the form of `projects/{PROJECT_ID}`.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "projects/[^/]+"
           }
         ],
         "tags": [

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,7 +3,7 @@ module github.com/grafeas/grafeas/tools
 go 1.14
 
 require (
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.0.1
 	google.golang.org/protobuf v1.27.1
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -50,6 +50,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -57,7 +59,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -102,8 +103,8 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -119,8 +120,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QGdLI4y34qQGjGWO0=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3 h1:I8MsauTJQXZ8df8qJvEln0kYNc3bSapuaSsEsnFdEFU=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3/go.mod h1:lZdb/YAJUSj9OqrCHs2ihjtoO3+xK3G53wTYXFWRGDo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -364,8 +365,8 @@ google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7Fc
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1 h1:b9mVrqYfq3P4bCdaLg1qtBnPzUYgglsIdjZkL/fQVOE=
-google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5 h1:zzNejm+EgrbLfDZ6lu9Uud2IVvHySPl8vQzf04laR5Q=
+google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -381,8 +382,8 @@ google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
-google.golang.org/grpc v1.42.0 h1:XT2/MFpuPFsEX2fWh3YQtHkZ+WYZFQRfaUgLZYj/p6A=
-google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
+google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.0.1 h1:M8spwkmx0pHrPq+uMdl22w5CvJ/Y+oAJTIs9oGoCpOE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.0.1/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
@@ -404,8 +405,9 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.3 h1:fvjTMHxHEw/mxHbtzPi3JCcKXQRAnQTBRo6YCJSVHKI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -417,3 +419,5 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=


### PR DESCRIPTION
Fixes #379
grpc-gateway recently updated to replace google.api.http paths with ones that meet the openapi specification.
see: 
https://github.com/grpc-ecosystem/grpc-gateway/pull/2461
https://github.com/grpc-ecosystem/grpc-gateway/pull/2496

One thing to note: grpc-gateway doesn't always (yet?) group operations in the same meaningful way that was intended in the proto file. This impacts the v1alpha1 grafeas.swagger.json in a small way, and was mitigated a bit more by reordering the grafeas.proto file.