### PR TITLE
Add a "benchmark_document" field to the compliance proto.

### DIFF
--- a/proto/v1/compliance.proto
+++ b/proto/v1/compliance.proto
@@ -52,6 +52,8 @@ message ComplianceVersion {
   // The CPE URI (https://cpe.mitre.org/specification/) this benchmark is
   // applicable to.
   string cpe_uri = 1;
+  // The name of the document that defines this benchmark, e.g. "CIS Container-Optimized OS".
+  string benchmark_document = 3;
   // The version of the benchmark. This is set to the version of the OS-specific
   // CIS document the benchmark is defined in.
   string version = 2;


### PR DESCRIPTION
This field will be used to store a reference to the document that defines the given benchmark, making it easier for product teams to look up information about compliance findings. For most OSes, each CPE URI will have a corresponding benchmark document.