### PR TITLE
Fix go1.18 vet error: (*testing.common).Error call has possible formatting directive.

### DIFF
--- a/go/filtering/common/source_test.go
+++ b/go/filtering/common/source_test.go
@@ -125,8 +125,8 @@ func TestStringSource_SnippetSingleline(t *testing.T) {
 		t.Errorf(UnexpectedSnippet, "hello, world", str)
 	}
 	if str2, found := source.Snippet(2); found {
-		t.Error(SnippetFound, 2)
+		t.Errorf(SnippetFound, 2)
 	} else if str2 != "" {
-		t.Error(UnexpectedSnippet, "", str2)
+		t.Errorf(UnexpectedSnippet, "", str2)
 	}
 }


### PR DESCRIPTION
`go vet` (go1.18) fails currently.
```
> go version
go version go1.18 darwin/amd64
> go vet ./...
# github.com/grafeas/grafeas/go/filtering/common
go/filtering/common/source_test.go:128:3: (*testing.common).Error call has possible formatting directive %d
go/filtering/common/source_test.go:130:3: (*testing.common).Error call has possible formatting directive %s
```
This pr fixes it.