### PR TITLE
Fixed issue #558 to return error when createNote with slash in NoteID

### DIFF
--- a/go/v1beta1/api/note.go
+++ b/go/v1beta1/api/note.go
@@ -16,6 +16,7 @@ package grafeas
 
 import (
 	"fmt"
+	"strings"
 
 	emptypb "github.com/golang/protobuf/ptypes/empty"
 	"github.com/grafeas/grafeas/go/name"
@@ -41,6 +42,9 @@ func (g *API) CreateNote(ctx context.Context, req *gpb.CreateNoteRequest) (*gpb.
 
 	if req.NoteId == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "a noteId must be specified")
+	}
+	if strings.Contains(req.NoteId, "/") {
+		return nil, status.Errorf(codes.InvalidArgument, "a noteId must not contain /")
 	}
 	if req.Note == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "a note must be specified")

--- a/go/v1beta1/api/note_test.go
+++ b/go/v1beta1/api/note_test.go
@@ -85,6 +85,15 @@ func TestCreateNoteErrors(t *testing.T) {
 			wantErrStatus: codes.InvalidArgument,
 		},
 		{
+			desc: "note ID contains /",
+			req: &gpb.CreateNoteRequest{
+				Parent: "projects/goog-vulnz",
+				NoteId: "CVE-UH-OH/TEST",
+				Note:   vulnzNote(t),
+			},
+			wantErrStatus: codes.InvalidArgument,
+		},
+		{
 			desc: "nil note",
 			req: &gpb.CreateNoteRequest{
 				Parent: "projects/goog-vulnz",


### PR DESCRIPTION
This is adding a new validation rule on NoteID in createNote to avoid using / as a part of NoteID.