### PR TITLE
Add Files to discovery occurrence to track files within a resource.

### DIFF
--- a/proto/v1/discovery.proto
+++ b/proto/v1/discovery.proto
@@ -121,4 +121,12 @@ message DiscoveryOccurrence {
 
   // The status of an SBOM generation.
   SBOMStatus sbom_status = 9;
+
+  message File {
+    string name = 1;
+    map<string, string> digest = 2;
+  }
+
+  // Files that make up the resource described by the occurrence.
+  repeated File files = 10;
 }

--- a/proto/v1/swagger/grafeas.swagger.json
+++ b/proto/v1/swagger/grafeas.swagger.json
@@ -930,6 +930,20 @@
       "default": "CONTINUOUS_ANALYSIS_UNSPECIFIED",
       "description": "Whether the resource is continuously analyzed.\n\n - CONTINUOUS_ANALYSIS_UNSPECIFIED: Unknown.\n - ACTIVE: The resource is continuously analyzed.\n - INACTIVE: The resource is ignored for continuous analysis."
     },
+    "DiscoveryOccurrenceFile": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "digest": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "DiscoveryOccurrenceSBOMStatus": {
       "type": "object",
       "properties": {
@@ -2281,6 +2295,13 @@
         "sbomStatus": {
           "$ref": "#/definitions/DiscoveryOccurrenceSBOMStatus",
           "description": "The status of an SBOM generation."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DiscoveryOccurrenceFile"
+          },
+          "description": "Files that make up the resource described by the occurrence."
         }
       },
       "description": "Provides information about the analysis status of a discovered resource."

--- a/proto/v1beta1/discovery.proto
+++ b/proto/v1beta1/discovery.proto
@@ -121,4 +121,13 @@ message Discovered {
 
   // The status of an SBOM generation.
   SBOMStatus sbom_status = 9;
+
+
+  message File {
+    string name = 1;
+    map<string, string> digest = 2;
+  }
+
+  // Files that make up the resource described by the occurrence.
+  repeated File files = 10;
 }

--- a/proto/v1beta1/swagger/grafeas.swagger.json
+++ b/proto/v1beta1/swagger/grafeas.swagger.json
@@ -915,6 +915,20 @@
       "default": "CONTINUOUS_ANALYSIS_UNSPECIFIED",
       "description": "Whether the resource is continuously analyzed.\n\n - CONTINUOUS_ANALYSIS_UNSPECIFIED: Unknown.\n - ACTIVE: The resource is continuously analyzed.\n - INACTIVE: The resource is ignored for continuous analysis."
     },
+    "DiscoveredFile": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "digest": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "DiscoveredSBOMStatus": {
       "type": "object",
       "properties": {
@@ -1599,6 +1613,13 @@
         "sbomStatus": {
           "$ref": "#/definitions/DiscoveredSBOMStatus",
           "description": "The status of an SBOM generation."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DiscoveredFile"
+          },
+          "description": "Files that make up the resource described by the occurrence."
         }
       },
       "description": "Provides information about the analysis status of a discovered resource."

--- a/proto/v1beta1/swagger/merged/grafeas.swagger.json
+++ b/proto/v1beta1/swagger/merged/grafeas.swagger.json
@@ -1061,6 +1061,20 @@
       "default": "CONTINUOUS_ANALYSIS_UNSPECIFIED",
       "description": "Whether the resource is continuously analyzed.\n\n - CONTINUOUS_ANALYSIS_UNSPECIFIED: Unknown.\n - ACTIVE: The resource is continuously analyzed.\n - INACTIVE: The resource is ignored for continuous analysis."
     },
+    "DiscoveredFile": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "digest": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "DiscoveredSBOMStatus": {
       "type": "object",
       "properties": {
@@ -1745,6 +1759,13 @@
         "sbomStatus": {
           "$ref": "#/definitions/DiscoveredSBOMStatus",
           "description": "The status of an SBOM generation."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DiscoveredFile"
+          },
+          "description": "Files that make up the resource described by the occurrence."
         }
       },
       "description": "Provides information about the analysis status of a discovered resource."


### PR DESCRIPTION
This account for cases where a "resource" is made up of multiple files, like a Java resource with a pom and jars, or a Python resource with a source tarball and wheels.