### PR TITLE
Add Files to discovery occurrence to track files within a resource.

### DIFF
--- a/proto/v1/discovery.proto
+++ b/proto/v1/discovery.proto
@@ -146,4 +146,12 @@ message DiscoveryOccurrence {
 
   // The status of an vulnerability attestation generation.
   VulnerabilityAttestation vulnerability_attestation = 10;
+
+  message File {
+    string name = 1;
+    map<string, string> digest = 2;
+  }
+
+  // Files that make up the resource described by the occurrence.
+  repeated File files = 11;
 }

--- a/proto/v1/swagger/grafeas.swagger.json
+++ b/proto/v1/swagger/grafeas.swagger.json
@@ -1551,6 +1551,20 @@
       "default": "CONTINUOUS_ANALYSIS_UNSPECIFIED",
       "description": "Whether the resource is continuously analyzed.\n\n - CONTINUOUS_ANALYSIS_UNSPECIFIED: Unknown.\n - ACTIVE: The resource is continuously analyzed.\n - INACTIVE: The resource is ignored for continuous analysis."
     },
+    "DiscoveryOccurrenceFile": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "digest": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "DiscoveryOccurrenceSBOMStatus": {
       "type": "object",
       "properties": {
@@ -2972,6 +2986,13 @@
         "vulnerabilityAttestation": {
           "$ref": "#/definitions/DiscoveryOccurrenceVulnerabilityAttestation",
           "description": "The status of an vulnerability attestation generation."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DiscoveryOccurrenceFile"
+          },
+          "description": "Files that make up the resource described by the occurrence."
         }
       },
       "description": "Provides information about the analysis status of a discovered resource."

--- a/proto/v1beta1/discovery.proto
+++ b/proto/v1beta1/discovery.proto
@@ -124,6 +124,14 @@ message Discovered {
 
   // The last time this resource was scanned.
   google.protobuf.Timestamp last_scan_time = 10;
-  
-  // Next ID: 11
+
+  message File {
+    string name = 1;
+    map<string, string> digest = 2;
+  }
+
+  // Files that make up the resource described by the occurrence.
+  repeated File files = 11;
+
+  // Next ID: 12
 }

--- a/proto/v1beta1/swagger/grafeas.swagger.json
+++ b/proto/v1beta1/swagger/grafeas.swagger.json
@@ -1580,6 +1580,20 @@
       "default": "CONTINUOUS_ANALYSIS_UNSPECIFIED",
       "description": "Whether the resource is continuously analyzed.\n\n - CONTINUOUS_ANALYSIS_UNSPECIFIED: Unknown.\n - ACTIVE: The resource is continuously analyzed.\n - INACTIVE: The resource is ignored for continuous analysis."
     },
+    "DiscoveredFile": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "digest": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "DiscoveredSBOMStatus": {
       "type": "object",
       "properties": {
@@ -2275,6 +2289,13 @@
           "type": "string",
           "format": "date-time",
           "description": "The last time this resource was scanned."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DiscoveredFile"
+          },
+          "description": "Files that make up the resource described by the occurrence."
         }
       },
       "description": "Provides information about the analysis status of a discovered resource."

--- a/proto/v1beta1/swagger/merged/grafeas.swagger.json
+++ b/proto/v1beta1/swagger/merged/grafeas.swagger.json
@@ -1726,6 +1726,20 @@
       "default": "CONTINUOUS_ANALYSIS_UNSPECIFIED",
       "description": "Whether the resource is continuously analyzed.\n\n - CONTINUOUS_ANALYSIS_UNSPECIFIED: Unknown.\n - ACTIVE: The resource is continuously analyzed.\n - INACTIVE: The resource is ignored for continuous analysis."
     },
+    "DiscoveredFile": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "digest": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "DiscoveredSBOMStatus": {
       "type": "object",
       "properties": {
@@ -2421,6 +2435,13 @@
           "type": "string",
           "format": "date-time",
           "description": "The last time this resource was scanned."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DiscoveredFile"
+          },
+          "description": "Files that make up the resource described by the occurrence."
         }
       },
       "description": "Provides information about the analysis status of a discovered resource."


### PR DESCRIPTION
This account for cases where a "resource" is made up of multiple files, like a Java resource with a pom and jars, or a Python resource with a source tarball and wheels.